### PR TITLE
Incorporate imagej1 windows

### DIFF
--- a/imagej/imagej.py
+++ b/imagej/imagej.py
@@ -334,6 +334,20 @@ def init(ij_dir_or_version_or_endpoint=None, headless=True, new_instance=False):
             return final_value
 
     ij.py = ImageJPython(ij)
+
+    if not headless:
+        WindowManager            = autoclass('ij.WindowManager')
+        ij.window = WindowManager
+        def to_window(array, name=None):
+            """
+            Converts the numpy array into an image window with the specified name
+            """
+            if name is None:
+                ij.ui().show(ij.py.to_java(array))
+            else:
+                ij.ui().show(name, ij.py.to_java(array))
+        ij.window.to_window = to_window
+
     return ij
 
 


### PR DESCRIPTION
This change makes it easy to work with ImageJ1 windows without needing to reference jnius or outside toolboxes.  These changes only happen if the JVM is not in headless mode.

First, it sets a new module ij.window to be the WindowManager.  This saves the awkward step of classifying the WindowManager outside the ij.init declaration.

Second, it creates a function to convert a numpy array to a window in ij.window.  The UIService is capable of doing this already, but it is not an intuitive way of transitioning between numpy and imagej.  This makes it much simpler and more clear how you are supposed to do so.
