### PR TITLE
Map ImgLib2 BitType to numpy dtype bool

### DIFF
--- a/imagej/imagej.py
+++ b/imagej/imagej.py
@@ -171,6 +171,7 @@ def init(ij_dir_or_version_or_endpoint=None, headless=True, new_instance=False):
             # -- ImgLib2 types --
             if jclass('net.imglib2.type.Type').isInstance(image_or_type):
                 ij2_types = {
+                    'net.imglib2.type.numeric.integer.BitType':           'bool',
                     'net.imglib2.type.numeric.integer.ByteType':          'int8',
                     'net.imglib2.type.numeric.integer.ShortType':         'int16',
                     'net.imglib2.type.numeric.integer.IntType':           'int32',


### PR DESCRIPTION
This adds explicit support for ImgLib2 `BitType`, that is now converted to `dtype('bool')` instead of the default `float64`.
As all of the `threshold` ops return `Iterable<BitType>`, I think this type should be explicitly supported.

Instead of `BitType`, we could also add `BooleanType` to cover both `BitType` and `BoolType`. What do you think about that, @ctrueden?
