### PR TITLE
Implement xarray <-> dataset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ env:
   - TRAVIS_PYTHON_VERSION=3.7
 os:
   - linux
+  - osx
+osx_image: xcode9.1
 dist: xenial
 services:
   - xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ env:
   - TRAVIS_PYTHON_VERSION=3.7
 os:
   - linux
-  - osx
-osx_image: xcode9.1
+dist: xenial
+services:
+  - xvfb
 install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
         MINICONDA_VERSION=2 ;

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -42,7 +42,7 @@ fi
 case "$(uname -s),$(uname -m)" in
 	Linux,x86_64) launcher=ImageJ-linux64 ;;
 	Linux,*) launcher=ImageJ-linux32 ;;
-	Darwin,*) launcher=Contents/MacOS/ImageJ-macosx ;;
+	Darwin,*) launcher=Contents/MacOS/ImageJ-macosx; skipGUI=1 ;;
 	MING*,*) launcher=ImageJ-win32.exe ;;
 	*) die "Unknown platform" ;;
 esac
@@ -64,7 +64,7 @@ unset JAVA_HOME
 
 # -- run tests with local Fiji.app --
 python -m pytest --ij="$ij_dir"
-python -m pytest --ij="$ij_dir" --headless=false
+test "$skipGUI" || python -m pytest --ij="$ij_dir" --headless=false
 
 # -- run tests with ImageJ from Maven repository --
 python -m pytest

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -63,9 +63,9 @@ python setup.py install
 unset JAVA_HOME
 
 # -- run tests with local Fiji.app --
+python -m pytest --ij="$ij_dir"
 python -m pytest --ij="$ij_dir" --headless=false
 
 # -- run tests with ImageJ from Maven repository --
 python -m pytest
 
-python -m pytest --ij="$ij_dir"

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -19,6 +19,7 @@ check () {
 conda create -n imagej -y python=$TRAVIS_PYTHON_VERSION
 source activate imagej
 conda env update -f environment.yml
+conda install pytest
 
 # -- ensure supporting tools are available --
 check curl git unzip
@@ -62,7 +63,9 @@ python setup.py install
 unset JAVA_HOME
 
 # -- run tests with local Fiji.app --
-python -O test/test_imagej.py --ij "$ij_dir"
+python -m pytest --ij="$ij_dir" --headless=false
 
 # -- run tests with ImageJ from Maven repository --
-python -m unittest discover test -v
+python -m pytest
+
+python -m pytest --ij="$ij_dir"

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,48 @@
+import imagej
+import pytest
+import argparse
+
+
+def pytest_addoption(parser):
+    """
+    Set up the command line parser for IJ location and headless mode
+    :param parser: pytest's parser, passed in automatically
+    :return: None
+    """
+    parser.addoption(
+        "--ij", action="store", default=None, help="directory to IJ"
+    )
+    parser.addoption(
+        "--headless", type=str2bool, action="store", default=True, help="Start in headless mode"
+    )
+
+
+@pytest.fixture(scope='session')
+def ij_fixture(request):
+    """
+    Create an ImageJ instance to be used by the whole testing environment
+    :param request: Pytest variable passed in to fixtures
+    :return: pyimageJ instance
+    """
+    ij_dir = request.config.getoption('--ij')
+    headless = request.config.getoption('--headless')
+
+    ij_wrapper = imagej.init(ij_dir, headless=headless)
+
+    return ij_wrapper
+
+
+def str2bool(v):
+    """
+    Convert string inputs into bool
+    :param v: A string
+    :return: Corresponding boolean
+    """
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected')

--- a/environment.yml
+++ b/environment.yml
@@ -10,3 +10,4 @@ dependencies:
   - scyjava
   - pillow # for server
   - requests # for server
+  - xarray

--- a/imagej/imagej.py
+++ b/imagej/imagej.py
@@ -320,7 +320,7 @@ def init(ij_dir_or_version_or_endpoint=None, headless=True, new_instance=False):
 
         def _xarray_to_dataset(self, xarr):
             """
-            Converts a xarray dataarray with specified dim order to an image
+            Converts a xarray dataarray to a dataset, inverting C-style (slow axis first) to F-style (slow-axis last)
             :param xarr: Pass an xarray dataarray and turn into a dataset.
             :return: The dataset
             """
@@ -459,7 +459,7 @@ def init(ij_dir_or_version_or_endpoint=None, headless=True, new_instance=False):
 
         def _dataset_to_xarray(self, dataset):
             """
-            Converts an ImageJ dataset into an xarray
+            Converts an ImageJ dataset into an xarray, inverting F-style (slow idx last) to C-style (slow idx first)
             :param dataset: ImageJ dataset
             :return: xarray with reversed (C-style) dims and coords as labeled by the dataset
             """

--- a/imagej/imagej.py
+++ b/imagej/imagej.py
@@ -329,10 +329,6 @@ def init(ij_dir_or_version_or_endpoint=None, headless=True, new_instance=False):
             axes = self._assign_axes(xarr)
             dataset.setAxes(axes)
 
-            # Currently, we have no handling for nonlinear axes, but I thought it should warn instead of fail.
-            if not self._axis_is_linear(xarr.coords):
-                warnings.warn("Not all axes are linear.  The nonlinear axes are not mapped correctly.")
-            
             self._assign_dataset_metadata(dataset, xarr.attrs)
 
             return dataset
@@ -394,23 +390,6 @@ def init(ij_dir_or_version_or_endpoint=None, headless=True, new_instance=False):
             :param attrs: Dictionary containing metadata
             """
             dataset.getProperties().putAll(self.to_java(attrs))
-
-        def _axis_is_linear(self, coords):
-            """
-            Check if each axis has linear steps between grid points.  Skip over axes with non-numeric entries
-            :param coords: Xarray coords variable, which is a dict with axis: [axis values]
-            :return: Whether all axes are linear, or not.
-            """
-            linear = True
-            for coord, values in coords.items():
-                try:
-                    diff = numpy.diff(coords)
-                    if len(numpy.unique(diff)) > 1:
-                        warnings.warn(f'Axis {coord} is not linear')
-                        linear = False
-                except TypeError:
-                    continue
-            return linear
 
         def _get_origin(self, axis):
             """

--- a/imagej/imagej.py
+++ b/imagej/imagej.py
@@ -364,7 +364,7 @@ def init(ij_dir_or_version_or_endpoint=None, headless=True, new_instance=False):
 
         def _assign_axes(self, xarr):
             """
-            Obtain xarray axes names, origin, and scale and convert into ImageJ Axis; currently supports LinearAxis.
+            Obtain xarray axes names, origin, and scale and convert into ImageJ Axis; currently supports EnumeratedAxis
             :param xarr: xarray that holds the units
             :return: A list of ImageJ Axis with the specified origin and scale
             """

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,9 @@ setup(
         'pillow', # for server
         'requests' # for server
     ],
+    tests_require=[
+        'pytest'
+    ],
     entry_points={
         'console_scripts': [
             'imagej=imagej.imagej:imagej_main'

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'numpy',
         'pyjnius',
         'scyjava',
+        'xarray',
         'pillow', # for server
         'requests' # for server
     ],

--- a/test/test_imagej.py
+++ b/test/test_imagej.py
@@ -16,9 +16,9 @@ else:
     ij = imagej.init(ij_dir)
 
 
-from jnius import autoclass
+from jnius import autoclass, cast
 import numpy as np
-
+import xarray as xr
 
 class TestImageJ(unittest.TestCase):
 
@@ -105,6 +105,62 @@ class TestImageJ(unittest.TestCase):
 
     def main(self):
         unittest.main()
+
+
+class TestXarrayConversion(unittest.TestCase):
+    def testCstyleArrayWithLabeledDimsConverts(self):
+        xarr = xr.DataArray(np.random.rand(5, 4, 3, 6, 12), dims=['T', 'Z', 'C', 'Y', 'X'],
+                             coords={'X': range(0, 12), 'Y': np.arange(0, 12, 2), 'C': ['R', 'G', 'B'],
+                                     'Z': np.arange(10, 50, 10), 'T': np.arange(0, 0.05, 0.01)},
+                             attrs={'Hello': 'Wrld'})
+
+        dataset = ij.py.to_java(xarr)
+        axes = [cast('net.imagej.axis.DefaultLinearAxis', dataset.axis(axnum)) for axnum in range(5)]
+        labels = [axis.type().getLabel() for axis in axes]
+        origins = [axis.origin() for axis in axes]
+        scales = [axis.scale() for axis in axes]
+
+        self.assertListEqual(origins, [0, 0, 0, 10, 0])
+        self.assertListEqual(scales, [1, 2, 1, 10, 0.01])
+
+        self.assertListEqual(list(reversed(xarr.dims)), labels)
+
+        self.assertEqual(xarr.attrs, ij.py.from_java(dataset.getProperties()))
+
+    def testFstyleArrayWiathLabeledDimsConverts(self):
+        xarr = xr.DataArray(np.ndarray([5, 4, 3, 6, 12], order='F'), dims=['t', 'z', 'c', 'y', 'x'],
+                            coords={'x': range(0, 12), 'y': np.arange(0, 12, 2),
+                                    'z': np.arange(10, 50, 10), 't': np.arange(0, 0.05, 0.01)},
+                            attrs={'Hello': 'Wrld'})
+
+        dataset = ij.py.to_java(xarr)
+        axes = [cast('net.imagej.axis.DefaultLinearAxis', dataset.axis(axnum)) for axnum in range(5)]
+        labels = [axis.type().getLabel() for axis in axes]
+        origins = [axis.origin() for axis in axes]
+        scales = [axis.scale() for axis in axes]
+
+        self.assertListEqual(origins, [0, 10, 0, 0, 0])
+        self.assertListEqual(scales, [0.01, 10, 1, 2, 1])
+
+        self.assertListEqual([dim.upper() for dim in xarr.dims], labels)
+        self.assertEqual(xarr.attrs, ij.py.from_java(dataset.getProperties()))
+
+    def testDatasetConvertsToXarray(self):
+        xarr = xr.DataArray(np.random.rand(5, 4, 3, 6, 12), dims=['t', 'z', 'c', 'y', 'x'],
+                             coords={'x': list(range(0, 12)), 'y': list(np.arange(0, 12, 2)), 'c': [0, 1, 2],
+                                     'z': list(np.arange(10, 50, 10)), 't': list(np.arange(0, 0.05, 0.01))},
+                             attrs={'Hello': 'Wrld'})
+
+        dataset = ij.py.to_java(xarr)
+
+        invert_xarr = ij.py.from_java(dataset)
+        self.assertTrue((xarr.values == invert_xarr.values).all())
+
+        self.assertEqual(list(xarr.dims), list(invert_xarr.dims))
+        for key in xarr.coords:
+            self.assertTrue((xarr.coords[key] == invert_xarr.coords[key]).all())
+        self.assertEqual(xarr.attrs, invert_xarr.attrs)
+
 
 
 if __name__ == '__main__':

--- a/test/test_imagej.py
+++ b/test/test_imagej.py
@@ -119,7 +119,7 @@ def assert_xarray_equal_to_dataset(ij_fixture, xarr):
     try:
         axes = [cast('net.imagej.axis.EnumeratedAxis', dataset.axis(axnum)) for axnum in range(5)]
     except JavaException:
-        axes = [cast('net.imagej.axis.DefaultLinearAxis', dataset.axis(axnum)) for axnum in range(5)]
+        axes = [cast('net.imagej.axis.LinearAxis', dataset.axis(axnum)) for axnum in range(5)]
 
     labels = [axis.type().getLabel() for axis in axes]
 
@@ -167,7 +167,7 @@ class TestXarrayConversion(object):
         try:
             axes = [cast('net.imagej.axis.EnumeratedAxis', dataset.axis(axnum)) for axnum in range(5)]
         except JavaException:
-            axes = [cast('net.imagej.axis.DefaultLinearAxis', dataset.axis(axnum)) for axnum in range(5)]
+            axes = [cast('net.imagej.axis.LinearAxis', dataset.axis(axnum)) for axnum in range(5)]
 
         labels = [axis.type().getLabel() for axis in axes]
         assert ['X' == 'Y', 'Z', 'T', 'C'], labels

--- a/test/test_imagej.py
+++ b/test/test_imagej.py
@@ -6,36 +6,21 @@ import pytest
 import numpy as np
 import xarray as xr
 
-if "--ij" in sys.argv:
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--ij', default='/Applications/Fiji.app', help="set ij_dir")
-    args = parser.parse_args()
-    print("set ij_dir to " + args.ij)
-    ij_dir = args.ij
-    ij = imagej.init(ij_dir)
-    sys.argv = sys.argv[2:]
-else:
-    ij_dir = 'net.imagej:imagej:222+net.imagej:imagej-legacy'
-    ij = imagej.init(ij_dir)
 
+class TestImageJ(object):
 
-from jnius import autoclass, cast
-
-
-class TestImageJ(unittest.TestCase):
-
-    def testFrangi(self):
+    def test_frangi(self, ij_fixture):
         input_array = np.array([[1000, 1000, 1000, 2000, 3000], [5000, 8000, 13000, 21000, 34000]])
         result = np.zeros(input_array.shape)
-        ij.op().filter().frangiVesselness(ij.py.to_java(result), ij.py.to_java(input_array), [1, 1], 4)
+        ij_fixture.op().filter().frangiVesselness(ij_fixture.py.to_java(result), ij_fixture.py.to_java(input_array), [1, 1], 4)
         correct_result = np.array([[0, 0, 0, 0.94282, 0.94283], [0, 0, 0, 0.94283, 0.94283]])
         result = np.ndarray.round(result, decimals=5)
-        self.assertTrue((result == correct_result).all())
+        assert (result == correct_result).all()
 
-    def testGaussian(self):
+    def test_gaussian(self, ij_fixture):
         input_array = np.array([[1000, 1000, 1000, 2000, 3000], [5000, 8000, 13000, 21000, 34000]])
 
-        output_array = ij.op().filter().gauss(ij.py.to_java(input_array), 10)
+        output_array = ij_fixture.op().filter().gauss(ij_fixture.py.to_java(input_array), 10)
         result = []
         correct_result = [8440, 8440, 8439, 8444]
         ra = output_array.randomAccess()
@@ -43,10 +28,10 @@ class TestImageJ(unittest.TestCase):
             for y in [0, 1]:
                 ra.setPosition(x, y)
                 result.append(ra.get().get())
-        self.assertEqual(result, correct_result)
+        assert result == correct_result
 
     """
-    def testTopHat(self):
+    def testTopHat(self, ij_fixture):
         ArrayList = autoclass('java.util.ArrayList')
         HyperSphereShape = autoclass('net.imglib2.algorithm.neighborhood.HyperSphereShape')
         Views = autoclass('net.imglib2.view.Views')
@@ -56,35 +41,36 @@ class TestImageJ(unittest.TestCase):
 
         input_array = np.array([[1000, 1000, 1000, 2000, 3000], [5000, 8000, 13000, 21000, 34000]])
         output_array = np.zeros(input_array.shape)
-        java_out = Views.iterable(ij.py.to_java(output_array))
-        java_in = ij.py.to_java(input_array)
+        java_out = Views.iterable(ij_fixture.py.to_java(output_array))
+        java_in = ij_fixture.py.to_java(input_array)
         shapes = ArrayList()
         shapes.add(HyperSphereShape(5))
 
-        ij.op().morphology().topHat(java_out, java_in, shapes)
+        ij_fixture.op().morphology().topHat(java_out, java_in, shapes)
         itr = java_out.iterator()
         while itr.hasNext():
             result.append(itr.next().get())
 
-        self.assertEqual(result, correct_result)
+        assert result == correct_result
     """
 
-    def testImageMath(self):
+    def test_image_math(self, ij_fixture):
+        from jnius import autoclass
         Views = autoclass('net.imglib2.view.Views')
 
         input_array = np.array([[1, 1, 2], [3, 5, 8]])
         result = []
         correct_result = [192, 198, 205, 192, 198, 204]
-        java_in = Views.iterable(ij.py.to_java(input_array))
-        java_out = ij.op().image().equation(java_in, "64 * (Math.sin(0.1 * p[0]) + Math.cos(0.1 * p[1])) + 128")
+        java_in = Views.iterable(ij_fixture.py.to_java(input_array))
+        java_out = ij_fixture.op().image().equation(java_in, "64 * (Math.sin(0.1 * p[0]) + Math.cos(0.1 * p[1])) + 128")
 
         itr = java_out.iterator()
         while itr.hasNext():
             result.append(itr.next().get())
-        self.assertEqual(result, correct_result)
+        assert result == correct_result
 
-    def testPluginsLoadUsingPairwiseStitching(self):
-        if ij_dir is None:
+    def test_plugins_load_using_pairwise_stitching(self, ij_fixture):
+        if not ij_fixture.legacy_enabled:
             # HACK: Skip test if not testing with a local Fiji.app.
             return
 
@@ -95,80 +81,94 @@ class TestImageJ(unittest.TestCase):
         plugin = 'Pairwise stitching'
         args = {'first_image': 'Tile1', 'second_image': 'Tile2'}
 
-        ij.script().run('macro.ijm', macro, True).get()
-        ij.py.run_plugin(plugin, args)
-        WindowManager = autoclass('ij.WindowManager')
+        ij_fixture.script().run('macro.ijm', macro, True).get()
+        ij_fixture.py.run_plugin(plugin, args)
+        from jnius import autoclass
+        WindowManager = autoclass('ij_fixture.WindowManager')
         result_name = WindowManager.getCurrentImage().getTitle()
 
-        ij.script().run('macro.ijm', 'run("Close All");', True).get()
+        ij_fixture.script().run('macro.ijm', 'run("Close All");', True).get()
 
-        self.assertEqual(result_name, 'Tile1<->Tile2')
-
-    def main(self):
-        unittest.main()
+        assert result_name == 'Tile1<->Tile2'
 
 
-class TestXarrayConversion(unittest.TestCase):
-    @classmethod
-    def setUp(cls):
-        cls.xarr = xr.DataArray(np.random.rand(5, 4, 6, 12, 3), dims=['t', 'z', 'y', 'x', 'c'],
+@pytest.fixture(scope='module')
+def get_xarr():
+    def _get_xarr(option='C'):
+        if option == 'C':
+            xarr = xr.DataArray(np.random.rand(5, 4, 6, 12, 3), dims=['t', 'z', 'y', 'x', 'c'],
                                 coords={'x': list(range(0, 12)), 'y': list(np.arange(0, 12, 2)), 'c': [0, 1, 2],
                                         'z': list(np.arange(10, 50, 10)), 't': list(np.arange(0, 0.05, 0.01))},
                                 attrs={'Hello': 'Wrld'})
-        cls.f_xarr = xr.DataArray(np.ndarray([5, 4, 3, 6, 12], order='F'), dims=['t', 'z', 'c', 'y', 'x'],
-                                  coords={'x': range(0, 12), 'y': np.arange(0, 12, 2),
-                                          'z': np.arange(10, 50, 10), 't': np.arange(0, 0.05, 0.01)},
-                                  attrs={'Hello': 'Wrld'})
-        cls.base_xarr = xr.DataArray(np.random.rand(1, 2, 3, 4, 5))
-
-    def testCstyleArrayWithLabeledDimsConverts(self):
-        self.assert_xarray_equal_to_dataset(self.xarr)
-
-    def testFstyleArrayWithLabeledDimsConverts(self):
-        self.assert_xarray_equal_to_dataset(self.f_xarr)
-
-    def assert_xarray_equal_to_dataset(self, xarr):
-        dataset = ij.py.to_java(xarr)
-        axes = [cast('net.imagej.axis.EnumeratedAxis', dataset.axis(axnum)) for axnum in range(5)]
-        labels = [axis.type().getLabel() for axis in axes]
-
-        for label, vals in xarr.coords.items():
-            cur_axis = axes[labels.index(label.upper())]
-            for loc in range(len(vals)):
-                self.assertEqual(vals[loc], cur_axis.calibratedValue(loc))
-
-        if np.isfortran(xarr.values):
-            expected_labels = [dim.upper() for dim in self.f_xarr.dims]
+        elif option == 'F':
+            xarr = xr.DataArray(np.ndarray([5, 4, 3, 6, 12], order='F'), dims=['t', 'z', 'c', 'y', 'x'],
+                                coords={'x': range(0, 12), 'y': np.arange(0, 12, 2),
+                                        'z': np.arange(10, 50, 10), 't': np.arange(0, 0.05, 0.01)},
+                                attrs={'Hello': 'Wrld'})
         else:
-            expected_labels = ['X', 'Y', 'Z', 'T', 'C']
+            xarr = xr.DataArray(np.random.rand(1, 2, 3, 4, 5))
 
-        self.assertListEqual(expected_labels, labels)
-        self.assertEqual(xarr.attrs, ij.py.from_java(dataset.getProperties()))
+        return xarr
+    return _get_xarr
 
-    def testDatasetConvertsToXarray(self):
-        dataset = ij.py.to_java(self.xarr)
-        self.assert_inverted_xarr_equal_to_xarr(dataset, self.xarr)
 
-    def testRGBImageMaintainsCorrectDimOrderOnConversion(self):
-        dataset = ij.py.to_java(self.xarr)
+def assert_xarray_equal_to_dataset(ij_fixture, xarr):
+    dataset = ij_fixture.py.to_java(xarr)
+
+    from jnius import cast
+    axes = [cast('net.imagej.axis.EnumeratedAxis', dataset.axis(axnum)) for axnum in range(5)]
+    labels = [axis.type().getLabel() for axis in axes]
+
+    for label, vals in xarr.coords.items():
+        cur_axis = axes[labels.index(label.upper())]
+        for loc in range(len(vals)):
+            assert vals[loc] == cur_axis.calibratedValue(loc)
+
+    if np.isfortran(xarr.values):
+        expected_labels = [dim.upper() for dim in xarr.dims]
+    else:
+        expected_labels = ['X', 'Y', 'Z', 'T', 'C']
+
+    assert expected_labels == labels
+    assert xarr.attrs == ij_fixture.py.from_java(dataset.getProperties())
+
+
+def assert_inverted_xarr_equal_to_xarr(dataset, ij_fixture, xarr):
+    # Reversing back to xarray yields original results
+    invert_xarr = ij_fixture.py.from_java(dataset)
+    assert (xarr.values == invert_xarr.values).all()
+    assert list(xarr.dims) == list(invert_xarr.dims)
+    for key in xarr.coords:
+        assert (xarr.coords[key] == invert_xarr.coords[key]).all()
+    assert xarr.attrs == invert_xarr.attrs
+
+
+class TestXarrayConversion(object):
+    def test_cstyle_array_with_labeled_dims_converts(self, ij_fixture, get_xarr):
+        assert_xarray_equal_to_dataset(ij_fixture, get_xarr())
+
+    def test_fstyle_array_with_labeled_dims_converts(self, ij_fixture, get_xarr):
+        assert_xarray_equal_to_dataset(ij_fixture, get_xarr('F'))
+
+    def test_dataset_converts_to_xarray(self, ij_fixture, get_xarr):
+        xarr = get_xarr()
+        dataset = ij_fixture.py.to_java(xarr)
+        assert_inverted_xarr_equal_to_xarr(dataset, ij_fixture, xarr)
+
+    def test_rgb_image_maintains_correct_dim_order_on_conversion(self, ij_fixture, get_xarr):
+        xarr = get_xarr()
+        dataset = ij_fixture.py.to_java(xarr)
         # Transforming to dataset preserves location of c channel
+        from jnius import cast
         axes = [cast('net.imagej.axis.EnumeratedAxis', dataset.axis(axnum)) for axnum in range(5)]
         labels = [axis.type().getLabel() for axis in axes]
-        self.assertEqual(['X', 'Y', 'Z', 'T', 'C'], labels)
-        self.assert_inverted_xarr_equal_to_xarr(dataset, self.xarr)
+        assert ['X' == 'Y', 'Z', 'T', 'C'], labels
+        assert_inverted_xarr_equal_to_xarr(dataset, ij_fixture, xarr)
 
-    def assert_inverted_xarr_equal_to_xarr(self, dataset, xarr):
-        # Reversing back to xarray yields original results
-        invert_xarr = ij.py.from_java(dataset)
-        self.assertTrue((xarr.values == invert_xarr.values).all())
-        self.assertEqual(list(xarr.dims), list(invert_xarr.dims))
-        for key in xarr.coords:
-            self.assertTrue((xarr.coords[key] == invert_xarr.coords[key]).all())
-        self.assertEqual(xarr.attrs, invert_xarr.attrs)
-
-    def test_no_coords_or_dims_in_xarr(self):
-        dataset = ij.py.from_java(self.base_xarr)
-        self.assert_inverted_xarr_equal_to_xarr(dataset, self.base_xarr)
+    def test_no_coords_or_dims_in_xarr(self, ij_fixture, get_xarr):
+        xarr = get_xarr('NoDims')
+        dataset = ij_fixture.py.from_java(xarr)
+        assert_inverted_xarr_equal_to_xarr(dataset, ij_fixture, xarr)
 
 
 @pytest.fixture(scope="module")
@@ -178,57 +178,57 @@ def arr():
 
 
 class TestIJ1ToIJ2Synchronization(object):
-    def testGetImagePlusSynchronizesFromIJ1ToIJ2(self, arr):
-        if not ij.legacy_enabled:
+    def test_get_image_plus_synchronizes_from_ij1_to_ij2(self, ij_fixture, arr):
+        if not ij_fixture.legacy_enabled:
             pytest.skip("No IJ1.  Skipping test.")
-        if ij.ui().isHeadless():
+        if ij_fixture.ui().isHeadless():
             pytest.skip("No GUI.  Skipping test")
 
         original = arr[0, 0]
-        ds = ij.py.to_java(arr)
-        ij.ui().show(ds)
+        ds = ij_fixture.py.to_java(arr)
+        ij_fixture.ui().show(ds)
         macro = """run("Add...", "value=5");"""
-        ij.py.run_macro(macro)
-        imp = ij.py.get_image_plus()
+        ij_fixture.py.run_macro(macro)
+        imp = ij_fixture.py.get_image_plus()
 
         assert arr[0, 0] == original + 5
 
-    def testSynchronizeFromIJ1ToNumpy(self, arr):
-        if not ij.legacy_enabled:
+    def test_synchronize_from_ij1_to_numpy(self, ij_fixture, arr):
+        if not ij_fixture.legacy_enabled:
             pytest.skip("No IJ1.  Skipping test.")
-        if ij.ui().isHeadless():
+        if ij_fixture.ui().isHeadless():
             pytest.skip("No GUI.  Skipping test")
 
         original = arr[0, 0]
-        ds = ij.py.to_dataset(arr)
-        ij.ui().show(ds)
-        imp = ij.py.get_image_plus()
+        ds = ij_fixture.py.to_dataset(arr)
+        ij_fixture.ui().show(ds)
+        imp = ij_fixture.py.get_image_plus()
         imp.getProcessor().add(5)
-        ij.py.synchronize_ij1_to_ij2(imp)
+        ij_fixture.py.synchronize_ij1_to_ij2(imp)
 
         assert arr[0, 0] == original + 5
 
-    def testWindowToNumpyConvertsActiveImageToXarray(self, arr):
-        if not ij.legacy_enabled:
+    def test_window_to_numpy_converts_active_image_to_xarray(self, ij_fixture, arr):
+        if not ij_fixture.legacy_enabled:
             pytest.skip("No IJ1.  Skipping test.")
-        if ij.ui().isHeadless():
+        if ij_fixture.ui().isHeadless():
             pytest.skip("No GUI.  Skipping test")
 
-        ds = ij.py.to_dataset(arr)
-        ij.ui().show(ds)
-        new_arr = ij.py.window_to_xarray()
+        ds = ij_fixture.py.to_dataset(arr)
+        ij_fixture.ui().show(ds)
+        new_arr = ij_fixture.py.window_to_xarray()
         assert (arr == new_arr.values).all
 
-    def testFunctionsThrowWarningIfLegacyNotEnabled(self):
-        if ij.legacy_enabled:
+    def test_functions_throw_warning_if_legacy_not_enabled(self, ij_fixture):
+        if ij_fixture.legacy_enabled:
             pytest.skip("IJ1 installed.  Skipping test")
 
         with pytest.raises(AttributeError):
-            ij.py.synchronize_ij1_to_ij2(None)
+            ij_fixture.py.synchronize_ij1_to_ij2(None)
         with pytest.raises(ImportError):
-            ij.py.get_image_plus()
+            ij_fixture.py.get_image_plus()
         with pytest.raises(ImportError):
-            ij.py.window_to_xarray()
+            ij_fixture.py.window_to_xarray()
 
 
 if __name__ == '__main__':

--- a/test/test_imagej.py
+++ b/test/test_imagej.py
@@ -115,7 +115,7 @@ class TestXarrayConversion(unittest.TestCase):
                              attrs={'Hello': 'Wrld'})
 
         dataset = ij.py.to_java(xarr)
-        axes = [cast('net.imagej.axis.DefaultLinearAxis', dataset.axis(axnum)) for axnum in range(5)]
+        axes = [cast('net.imagej.axis.LinearAxis', dataset.axis(axnum)) for axnum in range(5)]
         labels = [axis.type().getLabel() for axis in axes]
         origins = [axis.origin() for axis in axes]
         scales = [axis.scale() for axis in axes]
@@ -127,14 +127,14 @@ class TestXarrayConversion(unittest.TestCase):
 
         self.assertEqual(xarr.attrs, ij.py.from_java(dataset.getProperties()))
 
-    def testFstyleArrayWiathLabeledDimsConverts(self):
+    def testFstyleArrayWithLabeledDimsConverts(self):
         xarr = xr.DataArray(np.ndarray([5, 4, 3, 6, 12], order='F'), dims=['t', 'z', 'c', 'y', 'x'],
                             coords={'x': range(0, 12), 'y': np.arange(0, 12, 2),
                                     'z': np.arange(10, 50, 10), 't': np.arange(0, 0.05, 0.01)},
                             attrs={'Hello': 'Wrld'})
 
         dataset = ij.py.to_java(xarr)
-        axes = [cast('net.imagej.axis.DefaultLinearAxis', dataset.axis(axnum)) for axnum in range(5)]
+        axes = [cast('net.imagej.axis.LinearAxis', dataset.axis(axnum)) for axnum in range(5)]
         labels = [axis.type().getLabel() for axis in axes]
         origins = [axis.origin() for axis in axes]
         scales = [axis.scale() for axis in axes]
@@ -161,7 +161,8 @@ class TestXarrayConversion(unittest.TestCase):
             self.assertTrue((xarr.coords[key] == invert_xarr.coords[key]).all())
         self.assertEqual(xarr.attrs, invert_xarr.attrs)
 
-
+    def testRGBImageMaintainsCorrectDimOrderOnConversion(self):
+        return
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_imagej.py
+++ b/test/test_imagej.py
@@ -12,7 +12,7 @@ if "--ij" in sys.argv:
     ij = imagej.init(ij_dir)
     sys.argv = sys.argv[2:]
 else:
-    ij_dir = None  # Use newest release version, downloaded from Maven.
+    ij_dir = 'net.imagej:imagej:222'
     ij = imagej.init(ij_dir)
 
 
@@ -121,30 +121,29 @@ class TestXarrayConversion(unittest.TestCase):
 
     def testCstyleArrayWithLabeledDimsConverts(self):
         dataset = ij.py.to_java(self.xarr)
-        axes = [cast('net.imagej.axis.LinearAxis', dataset.axis(axnum)) for axnum in range(5)]
+        axes = [cast('net.imagej.axis.EnumeratedAxis', dataset.axis(axnum)) for axnum in range(5)]
         labels = [axis.type().getLabel() for axis in axes]
-        origins = [axis.origin() for axis in axes]
-        scales = [axis.scale() for axis in axes]
 
-        self.assertListEqual(origins, [0, 0, 10, 0, 0])
-        self.assertListEqual(scales, [1, 2, 10, 0.01, 1])
+        for label, vals in self.xarr.coords.items():
+            cur_axis = axes[labels.index(label.upper())]
+            for loc in range(len(vals)):
+                self.assertEqual(vals[loc], cur_axis.calibratedValue(loc))
 
         self.assertListEqual(['X', 'Y', 'Z', 'T', 'C'], labels)
-
         self.assertEqual(self.xarr.attrs, ij.py.from_java(dataset.getProperties()))
 
     def testFstyleArrayWithLabeledDimsConverts(self):
         dataset = ij.py.to_java(self.f_xarr)
-        axes = [cast('net.imagej.axis.LinearAxis', dataset.axis(axnum)) for axnum in range(5)]
+        axes = [cast('net.imagej.axis.EnumeratedAxis', dataset.axis(axnum)) for axnum in range(5)]
         labels = [axis.type().getLabel() for axis in axes]
-        origins = [axis.origin() for axis in axes]
-        scales = [axis.scale() for axis in axes]
 
-        self.assertListEqual(origins, [0, 10, 0, 0, 0])
-        self.assertListEqual(scales, [0.01, 10, 1, 2, 1])
+        for label, vals in self.f_xarr.coords.items():
+            cur_axis = axes[labels.index(label.upper())]
+            for loc in range(len(vals)):
+                self.assertEqual(vals[loc], cur_axis.calibratedValue(loc))
 
         self.assertListEqual([dim.upper() for dim in self.f_xarr.dims], labels)
-        self.assertEqual(self.xarr.attrs, ij.py.from_java(dataset.getProperties()))
+        self.assertEqual(self.f_xarr.attrs, ij.py.from_java(dataset.getProperties()))
 
     def testDatasetConvertsToXarray(self):
         dataset = ij.py.to_java(self.xarr)
@@ -159,7 +158,7 @@ class TestXarrayConversion(unittest.TestCase):
     def testRGBImageMaintainsCorrectDimOrderOnConversion(self):
         dataset = ij.py.to_java(self.xarr)
         # Transforming to dataset preserves location of c channel
-        axes = [cast('net.imagej.axis.LinearAxis', dataset.axis(axnum)) for axnum in range(5)]
+        axes = [cast('net.imagej.axis.EnumeratedAxis', dataset.axis(axnum)) for axnum in range(5)]
         labels = [axis.type().getLabel() for axis in axes]
         self.assertEqual(['X', 'Y', 'Z', 'T', 'C'], labels)
 


### PR DESCRIPTION
These changes address issue #17.

This new convention supports bi-directional conversion between xarrays and datasets, under the assumption that an xarray is an image.

Currently, this does flip the axes order for C-style (default) indexed xarrays, as Java uses F-style indexing.  This behavior conforms to the current status for regular numpy arrays.

Right now the conversion also assumes that the axes are linear, such that the axes can be defined with just an origin and a scale (aX + b).

Any non-numeric axes labels are currently lost (e.g., if you have coords of [R, G, B] they become [0, 1, 2] upon conversion)