### PR TITLE
Fix imagej/fiji version selection

### DIFF
--- a/imagej/__init__.py
+++ b/imagej/__init__.py
@@ -33,7 +33,6 @@ import os
 import re
 import sys
 
-import imglyb
 import numpy as np
 import scyjava as sj
 import xarray as xr
@@ -159,6 +158,7 @@ def init(ij_dir_or_version_or_endpoint=None, headless=True):
             _logger.debug('ImageJ version given: %s', version)
             sj.config.add_endpoints('net.imagej:imagej:' + version)
 
+    import imglyb
     sj.start_jvm()
 
     JObjectArray = JArray(JObject)


### PR DESCRIPTION
This commit moves the import of imglyb after setting the endpoints. If `net.imglib2:imglib2-limglyb:1.0.0` is the first endpoint in the list, imagej version 2.1.0 is loaded regardless of the specified version desired. This can be resolved by re-ordering
how the endpoints are sorted in `scyjava/__init__.py` or, in this case, moving the import of `imglyb` after the other endpoints have been added.

- [x] tests pass (10 pass, 4 skipped)  