### PR TITLE
Add python version for development environment

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -16,6 +16,7 @@ channels:
   - defaults
 dependencies:
   # Project dependencies
+  - python=3.6
   - imglyb
   - jpype1
   - numpy


### PR DESCRIPTION
This ensures that anyone who does development only uses features
available at Python 3.6

The version should be updated along with our minimum version requirement