### PR TITLE
Preserve image metadata in xarray <-> Dataset conversions

### DIFF
--- a/src/imagej/__init__.py
+++ b/src/imagej/__init__.py
@@ -655,6 +655,20 @@ class ImageJPython:
                 priority=sj.Priority.HIGH - 2,
             )
         )
+        sj.add_py_converter(
+            sj.Converter(
+                predicate=lambda obj: isinstance(obj, jc.ImageMetadata),
+                converter=lambda obj: convert.image_metadata_to_dict(self._ij, obj),
+                priority=sj.Priority.HIGH - 2,
+            )
+        )
+        sj.add_py_converter(
+            sj.Converter(
+                predicate=lambda obj: isinstance(obj, jc.MetadataWrapper),
+                converter=lambda obj: convert.metadata_wrapper_to_dict(self._ij, obj),
+                priority=sj.Priority.HIGH - 2,
+            )
+        )
 
     def _format_argument(self, key, value, ij1_style):
         if value is True:

--- a/src/imagej/_java.py
+++ b/src/imagej/_java.py
@@ -67,6 +67,14 @@ class JavaClasses(object):
         return "ij.ImagePlus"
 
     @blocking_import
+    def ImageMetadata(self):
+        return "io.scif.ImageMetadata"
+
+    @blocking_import
+    def MetadataWrapper(self):
+        return "io.scif.filters.MetadataWrapper"
+
+    @blocking_import
     def LabelingIOService(self):
         return "io.scif.labeling.LabelingIOService"
 
@@ -97,6 +105,10 @@ class JavaClasses(object):
     @blocking_import
     def CalibratedAxis(self):
         return "net.imagej.axis.CalibratedAxis"
+
+    @blocking_import
+    def ClassUtils(self):
+        return "org.scijava.util.ClassUtils"
 
     @blocking_import
     def Dimensions(self):

--- a/src/imagej/_java.py
+++ b/src/imagej/_java.py
@@ -123,6 +123,10 @@ class JavaClasses(object):
         return "net.imglib2.roi.labeling.ImgLabeling"
 
     @blocking_import
+    def Named(self):
+        return "org.scijava.Named"
+
+    @blocking_import
     def Util(self):
         return "net.imglib2.util.Util"
 

--- a/src/imagej/convert.py
+++ b/src/imagej/convert.py
@@ -168,6 +168,7 @@ def xarray_to_dataset(ij: "jc.ImageJ", xarr) -> "jc.Dataset":
         dataset = ndarray_to_dataset(ij, xarr.values)
     axes = dims._assign_axes(xarr)
     dataset.setAxes(axes)
+    dataset.setName(xarr.name)
     _assign_dataset_metadata(dataset, xarr.attrs)
 
     return dataset
@@ -238,7 +239,8 @@ def java_to_xarray(ij: "jc.ImageJ", jobj) -> xr.DataArray:
     xr_dims.reverse()
     xr_dims = dims._convert_dims(xr_dims, direction="python")
     xr_coords = dims._get_axes_coords(xr_axes, xr_dims, narr.shape)
-    return xr.DataArray(narr, dims=xr_dims, coords=xr_coords, attrs=xr_attrs)
+    name = jobj.getName() if isinstance(jobj, jc.Named) else None
+    return xr.DataArray(narr, dims=xr_dims, coords=xr_coords, attrs=xr_attrs, name=name)
 
 
 def supports_java_to_ndarray(ij: "jc.ImageJ", obj) -> bool:

--- a/src/imagej/stack.py
+++ b/src/imagej/stack.py
@@ -49,7 +49,7 @@ def rai_slice(rai, imin: Tuple, imax: Tuple, istep: Tuple):
         intervaled = Views.interval(rai, imin_fix, imax_fix)
         stepped = Views.subsample(intervaled, istep_fix)
 
-    # TODO: better mach NumPy squeeze behavior. See pyimagej/#1231
+    # TODO: better match NumPy squeeze behavior. See imagej/pyimagej#1231
     dimension_reduced = Views.dropSingletonDimensions(stepped)
     return dimension_reduced
 

--- a/tests/test_image_conversion.py
+++ b/tests/test_image_conversion.py
@@ -5,9 +5,6 @@ import pytest
 import scyjava as sj
 import xarray as xr
 
-# TODO: Change to scyjava.new_jarray once we have that function.
-from jpype import JArray, JInt, JLong
-
 import imagej.dims as dims
 
 # -- Fixtures --
@@ -18,7 +15,9 @@ def get_img(ij_fixture):
     def _get_img():
         # Create img
         CreateNamespace = sj.jimport("net.imagej.ops.create.CreateNamespace")
-        dims = JArray(JLong)([1, 2, 3, 4, 5])
+        dims = sj.jarray("j", [5])
+        for i in range(len(dims)):
+            dims[i] = i + 1
         ns = ij_fixture.op().namespace(CreateNamespace)
         img = ns.img(dims)
 
@@ -130,7 +129,7 @@ def assert_ndarray_equal_to_ndarray(narr_1, narr_2):
 
 def assert_ndarray_equal_to_img(img, nparr):
     cursor = img.cursor()
-    arr = JArray(JInt)(5)
+    arr = sj.jarray("i", [5])
     while cursor.hasNext():
         y = cursor.next().get()
         cursor.localize(arr)

--- a/tests/test_image_conversion.py
+++ b/tests/test_image_conversion.py
@@ -76,6 +76,8 @@ def get_nparr():
 
 @pytest.fixture(scope="module")
 def get_xarr():
+    name: str = "test_data_array"
+
     def _get_xarr(option="C"):
         if option == "C":
             xarr = xr.DataArray(
@@ -89,6 +91,7 @@ def get_xarr():
                     "t": list(np.arange(0, 0.05, 0.01)),
                 },
                 attrs={"Hello": "World"},
+                name=name,
             )
         elif option == "F":
             xarr = xr.DataArray(
@@ -101,9 +104,10 @@ def get_xarr():
                     "t": list(np.arange(0, 0.05, 0.01)),
                 },
                 attrs={"Hello": "World"},
+                name=name,
             )
         else:
-            xarr = xr.DataArray(np.random.rand(1, 2, 3, 4, 5))
+            xarr = xr.DataArray(np.random.rand(1, 2, 3, 4, 5), name=name)
 
         return xarr
 
@@ -121,6 +125,7 @@ def assert_inverted_xarr_equal_to_xarr(dataset, ij_fixture, xarr):
     for key in xarr.coords:
         assert (xarr.coords[key] == invert_xarr.coords[key]).all()
     assert xarr.attrs == invert_xarr.attrs
+    assert xarr.name == invert_xarr.name
 
 
 def assert_ndarray_equal_to_ndarray(narr_1, narr_2):
@@ -250,6 +255,7 @@ def assert_xarray_equal_to_dataset(ij_fixture, xarr):
 
     assert expected_labels == labels
     assert xarr.attrs == ij_fixture.py.from_java(dataset.getProperties())
+    assert xarr.name == ij_fixture.py.from_java(dataset.getName())
 
 
 def convert_img_and_assert_equality(ij_fixture, img):

--- a/tests/test_rai_arraylike.py
+++ b/tests/test_rai_arraylike.py
@@ -2,9 +2,6 @@ import numpy as np
 import pytest
 import scyjava as sj
 
-# TODO: Change to scyjava.new_jarray once we have that function.
-from jpype import JArray, JLong
-
 # -- Fixtures --
 
 
@@ -88,7 +85,10 @@ def test_slice_not_enough_dims(img):
 def test_step(img):
     # Create a stepped img via Views
     Views = sj.jimport("net.imglib2.view.Views")
-    steps = JArray(JLong)([1, 1, 2])
+    steps = sj.jarray("j", 3)
+    steps[0] = 1
+    steps[1] = 1
+    steps[2] = 2
     expected = Views.subsample(img, steps)
     # Create a stepped img via slicing notation
     actual = img[:, :, ::2]
@@ -101,7 +101,10 @@ def test_step(img):
 def test_step_not_enough_dims(img):
     # Create a stepped img via Views
     Views = sj.jimport("net.imglib2.view.Views")
-    steps = JArray(JLong)([2, 1, 1])
+    steps = sj.jarray("j", 3)
+    steps[0] = 2
+    steps[1] = 1
+    steps[2] = 1
     expected = Views.subsample(img, steps)
     expected = Views.dropSingletonDimensions(expected)
     # Create a stepped img via slicing notation
@@ -115,7 +118,9 @@ def test_slice_and_step(img):
     # Create a stepped img via Views
     Views = sj.jimport("net.imglib2.view.Views")
     intervaled = Views.hyperSlice(img, 0, 0)
-    steps = JArray(JLong)([1, 2])
+    steps = sj.jarray("j", 2)
+    steps[0] = 1
+    steps[1] = 2
     expected = Views.subsample(intervaled, steps)
     # Create a stepped img via slicing notation
     actual = img[:1, :, ::2]


### PR DESCRIPTION
Closes #200, #198

But we still need to figure out what "preserving image metadata" means in many cases. With the name, it's obvious, as both data structures have that as state. With other metadata like `ImageMetadata`, it's less obvious.

But discussion should go in #200 
