### PR TITLE
Remove redundant properties conversion

### DIFF
--- a/src/imagej/convert.py
+++ b/src/imagej/convert.py
@@ -231,7 +231,6 @@ def java_to_xarray(ij: "jc.ImageJ", jobj) -> xr.DataArray:
     xr_axes = list(permuted_rai.dim_axes)
     xr_dims = list(permuted_rai.dims)
     xr_attrs = sj.to_python(permuted_rai.getProperties())
-    xr_attrs = {sj.to_python(k): sj.to_python(v) for k, v in xr_attrs.items()}
     # reverse axes and dims to match narr
     xr_axes.reverse()
     xr_dims.reverse()


### PR DESCRIPTION
This call is not needed, because the call on the line before does nested conversion.

```
xr_attrs = sj.to_python(permuted_rai.getProperties())
```