### PR TITLE
Add an ij.py.show_ui function

### DIFF
--- a/src/imagej/__init__.py
+++ b/src/imagej/__init__.py
@@ -409,7 +409,7 @@ class ImageJPython:
             else:
                 ui.show()
 
-        self._ij.thread().queue(show_or_raise_ui)
+        ij.thread().queue(show_or_raise_ui)
 
     def sync_image(self, imp: "jc.ImagePlus" = None):
         """Synchronize data between ImageJ and ImageJ2.

--- a/src/imagej/__init__.py
+++ b/src/imagej/__init__.py
@@ -391,6 +391,26 @@ class ImageJPython:
         pyplot.imshow(self.from_java(image), interpolation="nearest", cmap=cmap)
         pyplot.show()
 
+    def show_ui(self, name: str = None) -> None:
+        """Display the ImageJ2 user interface.
+
+        :param name: The name of the ImageJ2 UI to show, or None for the
+                     default interface, which is "legacy" (the original ImageJ
+                     UI) when the add_legacy initialization flag is set, and
+                     "swing" (the "pure ImageJ2" UI) otherwise.
+        """
+
+        ij = self._ij
+
+        def show_or_raise_ui():
+            ui = ij.ui().getDefaultUI() if name is None else ij.ui().getUI(name)
+            if ui.isVisible():
+                ui.getApplicationFrame().setVisible(True)
+            else:
+                ui.show()
+
+        self._ij.thread().queue(show_or_raise_ui)
+
     def sync_image(self, imp: "jc.ImagePlus" = None):
         """Synchronize data between ImageJ and ImageJ2.
 


### PR DESCRIPTION
It takes care to show the UI on the AWT event dispatch thread.

If the UI is already visible, it raises the application frame instead of calling `ij.ui().showUI()` again, since SciJava Common currently has a bug when doing that where it hoses the UI (see scijava/scijava-common#460).

@elevans @hinerm @gselzer What do y'all think? Good? Or do you see any possible problems with this? If it were part of the PyImageJ library, I think it would reduce the code footprint of napari-imagej a little bit.
