### PR TITLE
Add conversion for BitType and BoolType imgs

### DIFF
--- a/src/imagej/images.py
+++ b/src/imagej/images.py
@@ -258,10 +258,19 @@ def _format_copy_exception(exc: str, fun_name: str) -> str:
     """
     # format cast exception
     exc = str(exc)
-    m = exc.split(" ")
     if "cannot be cast to" in exc:
+        m = exc.split(" ")
         from_class = m[m.index("cannot") - 1]
-        to_class = m[m.index("cast") + 3]
-        return f"Error: Unsupported type cast via {fun_name}\n    Source type: {from_class}\n    Target type: {to_class}"
+        # special case if "class" is present or not
+        ci = m.index("cast")
+        if m[ci + 2] == "class":
+            to_class = m[ci + 3]
+        else:
+            to_class = m[ci + 2]
+        return (
+            f"Error: Unsupported type cast via {fun_name}\n"
+            f"    Source type: {from_class}\n"
+            f"    Target type: {to_class}"
+        )
     else:
         return exc

--- a/src/imagej/images.py
+++ b/src/imagej/images.py
@@ -257,15 +257,11 @@ def _format_copy_exception(exc: str, fun_name: str) -> str:
     :return: The formatted exception.
     """
     # format cast exception
+    exc = str(exc)
     m = exc.split(" ")
-    from_class = ""
-    to_class = ""
-    if m[0] == "java.lang.ClassCastException:" and "net.imglib2.util" in fun_name:
-        from_class = m[2]
-        to_class = m[8]
-    elif m[0] == "java.lang.RuntimeException:" and "net.imagej.ops" in fun_name:
-        from_class = m[4]
-        to_class = m[10]
-    msg = f"Error: Unsupported type cast via {fun_name}\n    Source type: {from_class}\n    Target type: {to_class}"
-
-    return msg
+    if "cannot be cast to" in exc:
+        from_class = m[m.index("cannot") - 1]
+        to_class = m[m.index("cast") + 3]
+        return f"Error: Unsupported type cast via {fun_name}\n    Source type: {from_class}\n    Target type: {to_class}"
+    else:
+        return exc

--- a/src/imagej/images.py
+++ b/src/imagej/images.py
@@ -6,6 +6,7 @@ import logging
 
 import numpy as np
 import scyjava as sj
+from jpype import JException
 
 from imagej._java import jc
 
@@ -15,6 +16,8 @@ _logger = logging.getLogger(__name__)
 # fmt: off
 _imglib2_types = {
     "net.imglib2.type.logic.NativeBoolType":                          "bool_",
+    "net.imglib2.type.logic.BitType":                                 "bool_",
+    "net.imglib2.type.logic.BoolType":                                "bool_",
     "net.imglib2.type.numeric.integer.ByteType":                      "int8",
     "net.imglib2.type.numeric.integer.ByteLongAccessType":            "int8",
     "net.imglib2.type.numeric.integer.ShortType":                     "int16",
@@ -137,22 +140,25 @@ def copy_rai_into_ndarray(
     if not is_arraylike(narr):
         raise TypeError("narr is not arraylike")
 
-    # Check imglib2 version for fast copy availability.
-    imglib2_version = sj.get_version(jc.RandomAccessibleInterval)
-    if sj.is_version_at_least(imglib2_version, "5.9.0"):
-        # ImgLib2 is new enough to use net.imglib2.util.ImgUtil.copy.
-        ImgUtil = sj.jimport("net.imglib2.util.ImgUtil")
-        ImgUtil.copy(rai, sj.to_java(narr))
-        return narr
+    try:
+        # Check imglib2 version for fast copy availability.
+        imglib2_version = sj.get_version(jc.RandomAccessibleInterval)
+        if sj.is_version_at_least(imglib2_version, "5.9.0"):
+            # ImgLib2 is new enough to use net.imglib2.util.ImgUtil.copy.
+            ImgUtil = sj.jimport("net.imglib2.util.ImgUtil")
+            ImgUtil.copy(rai, sj.to_java(narr))
+            return narr
 
-    # Check imagej-common version for fast copy availability.
-    imagej_common_version = sj.get_version(jc.Dataset)
-    if sj.is_version_at_least(imagej_common_version, "0.30.0"):
-        # ImageJ Common is new enough to use (deprecated)
-        # net.imagej.util.Images.copy.
-        Images = sj.jimport("net.imagej.util.Images")
-        Images.copy(rai, sj.to_java(narr))
-        return narr
+        # Check imagej-common version for fast copy availability.
+        imagej_common_version = sj.get_version(jc.Dataset)
+        if sj.is_version_at_least(imagej_common_version, "0.30.0"):
+            # ImageJ Common is new enough to use (deprecated)
+            # net.imagej.util.Images.copy.
+            Images = sj.jimport("net.imagej.util.Images")
+            Images.copy(rai, sj.to_java(narr))
+            return narr
+    except JException:
+        pass
 
     # Fall back to copying with ImageJ Ops's copy.rai op. In theory, Ops
     # should always be faster. But in practice, the copy.rai operation is

--- a/src/imagej/images.py
+++ b/src/imagej/images.py
@@ -140,31 +140,48 @@ def copy_rai_into_ndarray(
     if not is_arraylike(narr):
         raise TypeError("narr is not arraylike")
 
-    try:
-        # Check imglib2 version for fast copy availability.
-        imglib2_version = sj.get_version(jc.RandomAccessibleInterval)
-        if sj.is_version_at_least(imglib2_version, "5.9.0"):
+    # Suppose all mechanisms fail. Any one of these might be the one that was
+    # "supposed" to work.
+    failure_exceptions = []
+
+    # Check imglib2 version for fast copy availability.
+    imglib2_version = sj.get_version(jc.RandomAccessibleInterval)
+    if sj.is_version_at_least(imglib2_version, "5.9.0"):
+        try:
             # ImgLib2 is new enough to use net.imglib2.util.ImgUtil.copy.
             ImgUtil = sj.jimport("net.imglib2.util.ImgUtil")
             ImgUtil.copy(rai, sj.to_java(narr))
             return narr
+        except JException as exc:
+            # Try another method
+            failure_exceptions.append(exc)
 
-        # Check imagej-common version for fast copy availability.
-        imagej_common_version = sj.get_version(jc.Dataset)
-        if sj.is_version_at_least(imagej_common_version, "0.30.0"):
+    # Check imagej-common version for fast copy availability.
+    imagej_common_version = sj.get_version(jc.Dataset)
+    if sj.is_version_at_least(imagej_common_version, "0.30.0"):
+        try:
             # ImageJ Common is new enough to use (deprecated)
             # net.imagej.util.Images.copy.
             Images = sj.jimport("net.imagej.util.Images")
             Images.copy(rai, sj.to_java(narr))
             return narr
-    except JException:
-        pass
+        except JException as exc:
+            # Try another method
+            failure_exceptions.append(exc)
 
     # Fall back to copying with ImageJ Ops's copy.rai op. In theory, Ops
     # should always be faster. But in practice, the copy.rai operation is
     # slower than the hardcoded ones above. If we were to fix Ops to be
     # fast always, we could eliminate the above special casing.
-    ij.op().run("copy.rai", sj.to_java(narr), rai)
+    try:
+        ij.op().run("copy.rai", sj.to_java(narr), rai)
+        return
+    except JException as exc:
+        # Try another method
+        failure_exceptions.append(exc)
+
+    # Failed
+    raise Exception("Could not copy rai into ndarray", *failure_exceptions)
 
 
 def dtype(image_or_type) -> np.dtype:

--- a/tests/test_image_conversion.py
+++ b/tests/test_image_conversion.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 import scyjava as sj
 import xarray as xr
+from jpype import JArray, JLong
 
 import imagej.convert as convert
 import imagej.dims as dims
@@ -374,6 +375,22 @@ def test_dataset_converts_to_xarray(ij):
     xarr = get_xarr()
     dataset = ij.py.to_java(xarr)
     assert_inverted_xarr_equal_to_xarr(dataset, ij, xarr)
+
+
+def test_bittype_img_to_ndarray(ij):
+    ArrayImgs = sj.jimport("net.imglib2.img.array.ArrayImgs")
+    dims = JArray(JLong)(3)
+    dims[:] = [10, 10, 10]
+    j_img = ArrayImgs.bits(dims)
+    p_img = ij.py.from_java(j_img)
+    assert p_img.dtype == np.bool_
+
+
+def test_boolean_ndarray_to_img(ij):
+    narr = np.ones((10, 10), dtype=np.bool_)
+    j_img = ij.py.to_java(narr)
+    BooleanType = sj.jimport("net.imglib2.type.BooleanType")
+    assert isinstance(j_img.firstElement(), BooleanType)
 
 
 def test_image_metadata_conversion(ij):

--- a/tests/test_image_conversion.py
+++ b/tests/test_image_conversion.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 import scyjava as sj
 import xarray as xr
-from jpype import JArray, JLong
+from jpype import JLong
 
 import imagej.convert as convert
 import imagej.dims as dims
@@ -379,8 +379,7 @@ def test_dataset_converts_to_xarray(ij):
 
 def test_bittype_img_to_ndarray(ij):
     ArrayImgs = sj.jimport("net.imglib2.img.array.ArrayImgs")
-    dims = JArray(JLong)(3)
-    dims[:] = [10, 10, 10]
+    dims = JLong[:] @ [10, 10, 10]
     j_img = ArrayImgs.bits(dims)
     p_img = ij.py.from_java(j_img)
     assert p_img.dtype == np.bool_

--- a/tests/test_image_conversion.py
+++ b/tests/test_image_conversion.py
@@ -5,7 +5,6 @@ import numpy as np
 import pytest
 import scyjava as sj
 import xarray as xr
-from jpype import JLong
 
 import imagej.convert as convert
 import imagej.dims as dims
@@ -378,9 +377,16 @@ def test_dataset_converts_to_xarray(ij):
 
 
 def test_bittype_img_to_ndarray(ij):
+    ops_version = sj.get_version(sj.jimport("net.imagej.ops.OpService"))
+    if not sj.is_version_at_least(ops_version, "2.1.0"):
+        pytest.skip("Fails without ImageJ Ops >= 2.1.0")
+
     ArrayImgs = sj.jimport("net.imglib2.img.array.ArrayImgs")
-    dims = JLong[:] @ [10, 10, 10]
+    # NB ArrayImgs requires a long[] - construct long[] {10, 10, 10}
+    dims = sj.jarray("j", 3)
+    dims[:] = [10] * 3
     j_img = ArrayImgs.bits(dims)
+
     p_img = ij.py.from_java(j_img)
     assert p_img.dtype == np.bool_
 


### PR DESCRIPTION
Using PyImageJ, functionality that returns boolean type images, like thresholds and morphology Ops, returns those images as images of `BitType` and/or `BoolType`. PyImageJ normally converts these to `DataArray`s of `float64`, which seems suboptimal.

This change, utilizing imagej/imagej-ops#651, allows those `BitType` and/or `BoolType` images to become *boolean* arrays instead. Of course, we will need to wait for that PR to make its way into release before we can merge this PR.

@elevans is there a better place to put the tests I wrote?