### PR TITLE
Simplify linear axis assignment logic

### DIFF
--- a/src/imagej/_java.py
+++ b/src/imagej/_java.py
@@ -55,12 +55,60 @@ class MyJavaClasses(JavaClasses):
         return "io.scif.labeling.LabelingIOService"
 
     @JavaClasses.java_import
+    def ChapmanRichardsAxis(self):
+        return "net.imagej.axis.ChapmanRichardsAxis"
+
+    @JavaClasses.java_import
     def DefaultLinearAxis(self):
         return "net.imagej.axis.DefaultLinearAxis"
 
     @JavaClasses.java_import
     def EnumeratedAxis(self):
         return "net.imagej.axis.EnumeratedAxis"
+
+    @JavaClasses.java_import
+    def ExponentialAxis(self):
+        return "net.imagej.axis.ExponentialAxis"
+
+    @JavaClasses.java_import
+    def ExponentialRecoveryAxis(self):
+        return "net.imagej.axis.ExponentialRecoveryAxis"
+
+    @JavaClasses.java_import
+    def GammaVariateAxis(self):
+        return "net.imagej.axis.GammaVariateAxis"
+
+    @JavaClasses.java_import
+    def GaussianAxis(self):
+        return "net.imagej.axis.GaussianAxis"
+
+    @JavaClasses.java_import
+    def IdentityAxis(self):
+        return "net.imagej.axis.IdentityAxis"
+
+    @JavaClasses.java_import
+    def InverseRodbardAxis(self):
+        return "net.imagej.axis.InverseRodbardAxis"
+
+    @JavaClasses.java_import
+    def LogLinearAxis(self):
+        return "net.imagej.axis.LogLinearAxis"
+
+    @JavaClasses.java_import
+    def PolynomialAxis(self):
+        return "net.imagej.axis.PolynomialAxis"
+
+    @JavaClasses.java_import
+    def PowerAxis(self):
+        return "net.imagej.axis.PowerAxis"
+
+    @JavaClasses.java_import
+    def RodbardAxis(self):
+        return "net.imagej.axis.RodbardAxis"
+
+    @JavaClasses.java_import
+    def VariableAxis(self):
+        return "net.iamgej.axis.VariableAxis"
 
     @JavaClasses.java_import
     def Dataset(self):

--- a/src/imagej/_java.py
+++ b/src/imagej/_java.py
@@ -51,6 +51,14 @@ class MyJavaClasses(JavaClasses):
         return "io.scif.labeling.LabelingIOService"
 
     @JavaClasses.java_import
+    def DefaultLinearAxis(self):
+        return "net.imagej.axis.DefaultLinearAxis"
+
+    @JavaClasses.java_import
+    def EnumeratedAxis(self):
+        return "net.imagej.axis.EnumeratedAxis"
+
+    @JavaClasses.java_import
     def Dataset(self):
         return "net.imagej.Dataset"
 

--- a/src/imagej/_java.py
+++ b/src/imagej/_java.py
@@ -31,6 +31,10 @@ class MyJavaClasses(JavaClasses):
     """
 
     @JavaClasses.java_import
+    def Double(self):
+        return "java.lang.Double"
+
+    @JavaClasses.java_import
     def Throwable(self):
         return "java.lang.Throwable"
 

--- a/src/imagej/_java.py
+++ b/src/imagej/_java.py
@@ -55,60 +55,12 @@ class MyJavaClasses(JavaClasses):
         return "io.scif.labeling.LabelingIOService"
 
     @JavaClasses.java_import
-    def ChapmanRichardsAxis(self):
-        return "net.imagej.axis.ChapmanRichardsAxis"
-
-    @JavaClasses.java_import
     def DefaultLinearAxis(self):
         return "net.imagej.axis.DefaultLinearAxis"
 
     @JavaClasses.java_import
     def EnumeratedAxis(self):
         return "net.imagej.axis.EnumeratedAxis"
-
-    @JavaClasses.java_import
-    def ExponentialAxis(self):
-        return "net.imagej.axis.ExponentialAxis"
-
-    @JavaClasses.java_import
-    def ExponentialRecoveryAxis(self):
-        return "net.imagej.axis.ExponentialRecoveryAxis"
-
-    @JavaClasses.java_import
-    def GammaVariateAxis(self):
-        return "net.imagej.axis.GammaVariateAxis"
-
-    @JavaClasses.java_import
-    def GaussianAxis(self):
-        return "net.imagej.axis.GaussianAxis"
-
-    @JavaClasses.java_import
-    def IdentityAxis(self):
-        return "net.imagej.axis.IdentityAxis"
-
-    @JavaClasses.java_import
-    def InverseRodbardAxis(self):
-        return "net.imagej.axis.InverseRodbardAxis"
-
-    @JavaClasses.java_import
-    def LogLinearAxis(self):
-        return "net.imagej.axis.LogLinearAxis"
-
-    @JavaClasses.java_import
-    def PolynomialAxis(self):
-        return "net.imagej.axis.PolynomialAxis"
-
-    @JavaClasses.java_import
-    def PowerAxis(self):
-        return "net.imagej.axis.PowerAxis"
-
-    @JavaClasses.java_import
-    def RodbardAxis(self):
-        return "net.imagej.axis.RodbardAxis"
-
-    @JavaClasses.java_import
-    def VariableAxis(self):
-        return "net.iamgej.axis.VariableAxis"
 
     @JavaClasses.java_import
     def Dataset(self):

--- a/src/imagej/dims.py
+++ b/src/imagej/dims.py
@@ -205,11 +205,11 @@ def _assign_axes(
                 jc.Double(np.double(x)) for x in np.arrange(len(xarr.coords[dim]))
             ]
 
-        # assign axis scale type -- checks for imagej metadata
+        # assign calibrated axis type -- checks for imagej metadata
         if "imagej" in xarr.attrs.keys():
             ij_dim = _convert_dim(dim, "java")
-            if ij_dim + "_axis_scale" in xarr.attrs["imagej"].keys():
-                scale_type = xarr.attrs["imagej"][ij_dim + "_axis_scale"]
+            if ij_dim + "_cal_axis_type" in xarr.attrs["imagej"].keys():
+                scale_type = xarr.attrs["imagej"][ij_dim + "_cal_axis_type"]
                 if scale_type == "linear":
                     jaxis = _get_linear_axis(ax_type, sj.to_java(doub_coords))
                 if scale_type == "enumerated":
@@ -483,3 +483,30 @@ def _to_ijdim(key: str) -> str:
         return ijdims[key]
     else:
         return key
+
+
+def _cal_axis_type_to_str(key) -> str:
+    """
+    Convert a CalibratedAxis type (e.g. net.imagej.axis.DefaultLinearAxis) to
+    a string.
+    """
+    cal_axis_types = {
+        jc.ChapmanRichardsAxis: "ChapmanRichardsAxis",
+        jc.DefaultLinearAxis: "DefaultLinearAxis",
+        jc.EnumeratedAxis: "EnumeratedAxis",
+        jc.ExponentialAxis: "ExponentialAxis",
+        jc.ExponentialRecoveryAxis: "ExponentialRecoveryAxis",
+        jc.GammaVariateAxis: "GammaVariateAxis",
+        jc.GaussianAxis: "GaussianAxis",
+        jc.IdentityAxis: "IdentityAxis",
+        jc.InverseRodbardAxis: "InverseRodbardAxis",
+        jc.LogLinearAxis: "LogLinearAxis",
+        jc.PolynomialAxis: "PolynomialAxis",
+        jc.PowerAxis: "PowerAxis",
+        jc.RodbardAxis: "RodbardAxis",
+    }
+
+    if key.__class__ in cal_axis_types:
+        return cal_axis_types[key.__class__]
+    else:
+        return "unknown"

--- a/src/imagej/dims.py
+++ b/src/imagej/dims.py
@@ -215,19 +215,18 @@ def _assign_axes(
 
         # For non-linear scales, use EnumeratedAxis
         try:
-            EnumeratedAxis = sj.jimport("net.imagej.axis.EnumeratedAxis")
+            if not linear:
+                j_coords = [jc.Double(x) for x in coords_arr]
+                axes[ax_num] = jc.EnumeratedAxis(ax_type, sj.to_java(j_coords))
+                continue
         except (JException, TypeError):
-            EnumeratedAxis = None
-        # If we can use EnumeratedAxis for a nonlinear scale, then use it
-        if not linear and EnumeratedAxis:
-            j_coords = [jc.Double(x) for x in coords_arr]
-            axes[ax_num] = EnumeratedAxis(ax_type, sj.to_java(j_coords))
-        # Otherwise, use DefaultLinearAxis
-        else:
-            DefaultLinearAxis = sj.jimport("net.imagej.axis.DefaultLinearAxis")
+            # We don't have EnumeratedAxis available - use DefaultLinearAxis
+            pass
+        # For linear scales, use DefaultLinearAxis
+        finally:
             scale = coords_arr[1] - coords_arr[0] if len(coords_arr) > 1 else 1
             origin = coords_arr[0] if len(coords_arr) > 0 else 0
-            axes[ax_num] = DefaultLinearAxis(
+            axes[ax_num] = jc.DefaultLinearAxis(
                 ax_type, jc.Double(scale), jc.Double(origin)
             )
 

--- a/src/imagej/dims.py
+++ b/src/imagej/dims.py
@@ -199,15 +199,17 @@ def _assign_axes(
         axis_str = _convert_dim(dim, "java")
         ax_type = jc.Axes.get(axis_str)
         ax_num = _get_axis_num(xarr, dim)
-        coords_arr = xarr.coords[dim].to_numpy().astype(np.double)
+        coords_arr = xarr.coords[dim]
 
         # coerce numeric scale
         if not _is_numeric_scale(coords_arr):
             _logger.warning(
-                f"The {ax_type.label} axis is non-numeric and is translated "
+                f"The {ax_type.getLabel()} axis is non-numeric and is translated "
                 "to a linear index."
             )
-            coords_arr = [np.double(x) for x in np.arrange(len(xarr.coords[dim]))]
+            coords_arr = [np.double(x) for x in np.arange(len(xarr.coords[dim]))]
+        else:
+            coords_arr = coords_arr.to_numpy().astype(np.double)
 
         # check scale linearity
         diffs = np.diff(coords_arr)


### PR DESCRIPTION
I split this PR from my metadata PR (https://github.com/imagej/pyimagej/pull/247). This PR aims to simply how we assign calibrated linear axes to datasets. Currently we check if `net.imagej.axis.EnumeratedAxis` is available and use that as our first choice. If `net.imagej.axis.EnumeratedAxis` is not available, then we fall back to `net.imagej.axis.DefaultLinearAxis`. This is fine for most things, but unfortunately this logic has some unintended consequences. @gselzer informed me that the BoneJ plugin actually checks for `net.imagej.axis.DefaultLinearAxis` and is unable to use the `net.imagej.axis.EnumeratedAxis`. The changes this PR brings are the following:

- Drop `net.imagej.axis.EnumeratedAxis` from the axes assignment logic. While I would like to keep the option to use both, I don't realistically see how a user would indicate they want `EnumeratedAxis` or not. Also if they actually care about that, then it seems likely that they may have enough knowledge to change the `CalibratedAxis` type. Are there instances where ImageJ2 will produce a `net.imagej.Dataset` with `net.imagej.axis.EnumeratedAxis`? If not, then I think that is another point for dropping this behavior.
- Resolve singleton dimension scale bug. I thought I got this into `main` already but I realize it has been passed around from one stale PR to another. Here it is! This change resolves a bug where getting the scale of a singleton dimension fails. This is because we calculate the slope from the dimensions coordinate array. The first two values are used for this math, which of course fails for singleton dimensions because their coordinate array is size `1`. Thus all singleton dimensions should have their scale set to `1`.

## update 1

Thanks @gselzer for adding in a good way to have both `EnumeratedAxis` and `DefaultLinearAxis` as options based on coordinate array linearity.

Things for me to do:

TODO:

- [x] Write tests for new scale logic.

## update 2

I've added the following changes:

- Remove the `Finally` block and slightly reworked the logic. `Finally` was always triggered and replaced the `EnumeratedAxis` with `DefaultLinearAxis`.
- Added tests for:
   - linear coords -> `DefaultLinearAxis`
   - non-linear coords -> `EnumeratedAxis`
   - non-numeric coords -> `DefaultLinearAxis` 