### PR TITLE
Add converter for `ij.measure.ResultsTable` to `pandas.DataFarme`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.8", "3.10"]
         # Breaks due to https://github.com/jpype-project/jpype/issues/1009
         # Should be included once the fix is released
         exclude:

--- a/src/imagej/__init__.py
+++ b/src/imagej/__init__.py
@@ -678,15 +678,17 @@ class ImageJPython:
                 priority=sj.Priority.HIGH - 2,
             )
         )
-        sj.add_py_converter(
-            sj.Converter(
-                predicate=lambda obj: isinstance(obj, jc.ResultsTable),
-                converter=lambda obj: self.from_java(
-                    convert.results_table_to_scijava_table(self._ij, obj)
-                ),
-                priority=sj.Priority.HIGH + 2,
+        # add the ij.measure.ResultsTable converter only if legacy is enabled
+        if self._ij.legacy and self._ij.legacy.isActive():
+            sj.add_py_converter(
+                sj.Converter(
+                    predicate=lambda obj: isinstance(obj, jc.ResultsTable),
+                    converter=lambda obj: self.from_java(
+                        convert.results_table_to_scijava_table(self._ij, obj)
+                    ),
+                    priority=sj.Priority.HIGH + 2,
+                )
             )
-        )
 
     def _format_argument(self, key, value, ij1_style):
         if value is True:

--- a/src/imagej/__init__.py
+++ b/src/imagej/__init__.py
@@ -678,6 +678,15 @@ class ImageJPython:
                 priority=sj.Priority.HIGH - 2,
             )
         )
+        sj.add_py_converter(
+            sj.Converter(
+                predicate=lambda obj: isinstance(obj, jc.ResultsTable),
+                converter=lambda obj: self.from_java(
+                    convert.results_table_to_scijava_table(self._ij, obj)
+                ),
+                priority=sj.Priority.HIGH + 2,
+            )
+        )
 
     def _format_argument(self, key, value, ij1_style):
         if value is True:

--- a/src/imagej/_java.py
+++ b/src/imagej/_java.py
@@ -39,6 +39,10 @@ class MyJavaClasses(JavaClasses):
         return "ij.ImagePlus"
 
     @JavaClasses.java_import
+    def ResultsTable(self):
+        return "ij.measure.ResultsTable"
+
+    @JavaClasses.java_import
     def ImageMetadata(self):
         return "io.scif.ImageMetadata"
 
@@ -109,6 +113,10 @@ class MyJavaClasses(JavaClasses):
     @JavaClasses.java_import
     def Named(self):
         return "org.scijava.Named"
+
+    @JavaClasses.java_import
+    def Table(self):
+        return "org.scijava.table.Table"
 
     @JavaClasses.java_import
     def Util(self):

--- a/src/imagej/convert.py
+++ b/src/imagej/convert.py
@@ -504,6 +504,24 @@ def metadata_wrapper_to_dict(ij: "jc.ImageJ", metadata_wrapper: "jc.MetadataWrap
 
 
 ####################
+# Table converters #
+####################
+
+
+def results_table_to_scijava_table(
+    ij: "jc.ImageJ", table: "jc.ResultsTable"
+) -> "jc.Table":
+    """
+    Converts an ij.measure.ResultsTable to an org.scijava.table.Table.
+
+    :param ij: The ImageJ2 gateway (see imagej.init)
+    :param table: The ResultsTable to convert.
+    :return: A Java org.scijava.table.Table
+    """
+    return ij.convert().convert(table, jc.Table)
+
+
+####################
 # Helper functions #
 ####################
 

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -146,6 +146,8 @@ def test_functions_throw_warning_if_legacy_not_enabled(ij_fixture):
 
 
 def test_results_table_to_pandas_dataframe(ij_fixture, results_table):
+    ensure_legacy_enabled(ij_fixture)
+
     df = ij_fixture.py.from_java(results_table)
     for col in range(5):
         rt_col = list(results_table.getColumn(col))

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -1,5 +1,8 @@
+import random
+
 import numpy as np
 import pytest
+import scyjava as sj
 
 # -- Fixtures --
 
@@ -8,6 +11,24 @@ import pytest
 def arr():
     empty_array = np.zeros([512, 512])
     return empty_array
+
+
+@pytest.fixture(scope="module")
+def results_table():
+    ResultsTable = sj.jimport("ij.measure.ResultsTable")
+    rt = ResultsTable.getResultsTable()
+
+    # add column headers
+    for i in range(5):
+        rt.setHeading(i, f"Column {i}")
+
+    # add data rows
+    for i in range(3):
+        rt.incrementCounter()
+        for j in range(5):
+            rt.addValue(f"Column {j}", random.randint(1, 100))
+
+    return rt
 
 
 # -- Helpers --
@@ -122,3 +143,11 @@ def test_functions_throw_warning_if_legacy_not_enabled(ij_fixture):
 
     with pytest.raises(ImportError):
         ij_fixture.py.active_imageplus()
+
+
+def test_results_table_to_pandas_dataframe(ij_fixture, results_table):
+    df = ij_fixture.py.from_java(results_table)
+    for col in range(5):
+        rt_col = list(results_table.getColumn(col))
+        df_col = df[f"Column {col}"].tolist()
+        assert rt_col == df_col

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -14,19 +14,22 @@ def arr():
 
 
 @pytest.fixture(scope="module")
-def results_table():
-    ResultsTable = sj.jimport("ij.measure.ResultsTable")
-    rt = ResultsTable.getResultsTable()
+def results_table(ij_fixture):
+    if ij_fixture.legacy and ij_fixture.legacy.isActive():
+        ResultsTable = sj.jimport("ij.measure.ResultsTable")
+        rt = ResultsTable.getResultsTable()
 
-    # add column headers
-    for i in range(5):
-        rt.setHeading(i, f"Column {i}")
+        # add column headers
+        for i in range(5):
+            rt.setHeading(i, f"Column {i}")
 
-    # add data rows
-    for i in range(3):
-        rt.incrementCounter()
-        for j in range(5):
-            rt.addValue(f"Column {j}", random.randint(1, 100))
+        # add data rows
+        for i in range(3):
+            rt.incrementCounter()
+            for j in range(5):
+                rt.addValue(f"Column {j}", random.randint(1, 100))
+    else:
+        pytest.skip("No original ImageJ. Skipping fixture.")
 
     return rt
 


### PR DESCRIPTION
This PR address issue https://github.com/imagej/pyimagej/issues/250. Currently we do not have a converter for `ij.measure.ResultsTable`. This means that `ij.py.from_java(ResultsTable)` calls fail (unfortunately, they do not fail gently at the moment). To get a `pandas.DataFrame` you need to first convert your `ij.measure.ResultsTable` to a `org.scijava.table.Table` object before calling `ij.py.from_java()` on it to trigger the conversion. I added a `ij.measure.ResultsTable` to a `org.scijava.table.Table` converter and a tests for it.