### PR TITLE
Add callback mechanism for GUI mode

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -43,6 +43,8 @@ def ij(request):
     legacy = request.config.getoption("--legacy")
     headless = request.config.getoption("--headless")
 
+    imagej.when_imagej_starts(lambda ij: setattr(ij, "_when_imagej_starts_result", "success"))
+
     mode = "headless" if headless else "interactive"
     ij = imagej.init(ij_dir, mode=mode, add_legacy=legacy)
 

--- a/conftest.py
+++ b/conftest.py
@@ -34,7 +34,7 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(scope="session")
-def ij_fixture(request):
+def ij(request):
     """
     Create an ImageJ instance to be used by the whole testing environment
     :param request: Pytest variable passed in to fixtures
@@ -44,11 +44,11 @@ def ij_fixture(request):
     headless = request.config.getoption("--headless")
 
     mode = "headless" if headless else "interactive"
-    ij_wrapper = imagej.init(ij_dir, mode=mode, add_legacy=legacy)
+    ij = imagej.init(ij_dir, mode=mode, add_legacy=legacy)
 
-    yield ij_wrapper
+    yield ij
 
-    ij_wrapper.dispose()
+    ij.dispose()
 
 
 def str2bool(v):

--- a/conftest.py
+++ b/conftest.py
@@ -43,7 +43,9 @@ def ij(request):
     legacy = request.config.getoption("--legacy")
     headless = request.config.getoption("--headless")
 
-    imagej.when_imagej_starts(lambda ij: setattr(ij, "_when_imagej_starts_result", "success"))
+    imagej.when_imagej_starts(
+        lambda ij: setattr(ij, "_when_imagej_starts_result", "success")
+    )
 
     mode = "headless" if headless else "interactive"
     ij = imagej.init(ij_dir, mode=mode, add_legacy=legacy)

--- a/conftest.py
+++ b/conftest.py
@@ -43,9 +43,7 @@ def ij(request):
     legacy = request.config.getoption("--legacy")
     headless = request.config.getoption("--headless")
 
-    imagej.when_imagej_starts(
-        lambda ij: setattr(ij, "_when_imagej_starts_result", "success")
-    )
+    imagej.when_imagej_starts(lambda ij: setattr(ij, "_testing", True))
 
     mode = "headless" if headless else "interactive"
     ij = imagej.init(ij_dir, mode=mode, add_legacy=legacy)

--- a/doc/05-Convenience-methods-of-PyImageJ.ipynb
+++ b/doc/05-Convenience-methods-of-PyImageJ.ipynb
@@ -129,6 +129,31 @@
    "source": [
     "Note the warnings! We're currently in headless mode. The many legacy ImageJ functions operate limitedly or not at all in headless mode. For example the `RoiManager` is not functional in a true headless enviornment."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5.2 Register functions to start with ImageJ\n",
+    "\n",
+    "Functions can be executed during ImageJ's initialization routine by registering the functions with PyImageJ's callback mechanism `when_imagej_starts()`. This is particularly useful for macOS users in `gui` mode, allowing functions to be called before the Python [REPL/interpreter](https://docs.python.org/3/tutorial/interpreter.html) is [blocked](Initialization.md/#gui-mode).\n",
+    "\n",
+    "The following example uses `when_imagej_starts()` callback display a to `uint16` 2D NumPy array it with ImageJ's viewer, print it's dimensions (_i.e._ shape) and open the `RoiManager` while ImageJ initializes.\n",
+    "\n",
+    "```python\n",
+    "import imagej\n",
+    "import numpy as np\n",
+    "\n",
+    "# register functions\n",
+    "arr = np.random.randint(0, 2**16, size=(256, 256), dtype=np.uint16) # create random 16-bit array\n",
+    "imagej.when_imagej_starts(lambda ij: ij.RoiManager.getRoiManager()) # open the RoiManager\n",
+    "imagej.when_imagej_starts(lambda ij: ij.ui().show(ij.py.to_dataset(arr))) # convert and display the array\n",
+    "imagej.when_imagej_starts(lambda _: print(f\"array shape: {arr.shape}\"))\n",
+    "\n",
+    "# initialize imagej\n",
+    "ij = imagej.init(mode='interactive')\n",
+    "```"
+   ]
   }
  ],
  "metadata": {

--- a/src/imagej/__init__.py
+++ b/src/imagej/__init__.py
@@ -1214,10 +1214,12 @@ def init(
 
     if mode == Mode.GUI:
         # Show the GUI and block.
+        global gateway
         if macos:
             # NB: This will block the calling (main) thread forever!
             try:
-                setupGuiEnvironment(lambda: _create_gateway().ui().showUI())
+                gateway = _create_gateway()
+                setupGuiEnvironment(lambda: gateway.ui().showUI())
             except ModuleNotFoundError as e:
                 if e.msg == "No module named 'PyObjCTools'":
                     advice = (
@@ -1243,7 +1245,8 @@ def init(
             # TODO: Poll using something better than ui().isVisible().
             while gateway.ui().isVisible():
                 time.sleep(1)
-            return None
+        del gateway
+        return None
     else:
         # HEADLESS or INTERACTIVE mode: create the gateway and return it.
         return _create_gateway()

--- a/src/imagej/__init__.py
+++ b/src/imagej/__init__.py
@@ -60,7 +60,7 @@ __author__ = "ImageJ2 developers"
 __version__ = sj.get_version("pyimagej")
 
 _logger = logging.getLogger(__name__)
-rai_lock = threading.Lock()
+_rai_lock = threading.Lock()
 
 # Enable debug logging if DEBUG environment variable is set.
 try:
@@ -1007,14 +1007,14 @@ class RAIOperators(object):
     def _ra(self):
         threadLocal = getattr(self, "_threadLocal", None)
         if threadLocal is None:
-            with rai_lock:
+            with _rai_lock:
                 threadLocal = getattr(self, "_threadLocal", None)
                 if threadLocal is None:
                     threadLocal = threading.local()
                     self._threadLocal = threadLocal
         ra = getattr(threadLocal, "ra", None)
         if ra is None:
-            with rai_lock:
+            with _rai_lock:
                 ra = getattr(threadLocal, "ra", None)
                 if ra is None:
                     ra = self.randomAccess()

--- a/src/imagej/__init__.py
+++ b/src/imagej/__init__.py
@@ -1530,10 +1530,13 @@ def _macos_is_main_thread():
     # try to load the pthread library
     try:
         pthread = cdll.LoadLibrary("libpthread.dylib")
-    except OSError as e:
-        print("No pthread library found.", e)
+    except OSError as exc:
+        _log_exception(_logger, exc)
+        print("No pthread library found.")
+        # assume the current thread is the main thread
+        return True
 
-    # detect if main thread
+    # detect if the current thread is the main thread
     if pthread.pthread_main_np() == 1:
         return True
     else:

--- a/src/imagej/__init__.py
+++ b/src/imagej/__init__.py
@@ -1227,6 +1227,7 @@ def init(
     if mode == Mode.GUI:
         # Show the GUI and block.
         global gateway
+        gateway = None
 
         def show_gui_and_run_callbacks():
             global gateway
@@ -1261,10 +1262,11 @@ def init(
             gateway = show_gui_and_run_callbacks()
             # We are responsible for our own blocking.
             # TODO: Poll using something better than ui().isVisible().
-            while gateway.ui().isVisible():
+            while sj.jvm_started() and gateway.ui().isVisible():
                 time.sleep(1)
 
-        return gateway
+        del gateway
+        return None
 
     # HEADLESS or INTERACTIVE mode: create the gateway and return it.
     return run_callbacks(_create_gateway())

--- a/src/imagej/__init__.py
+++ b/src/imagej/__init__.py
@@ -1223,15 +1223,17 @@ def init(
         # Show the GUI and block.
         global gateway
 
-        def show_gui_and_run_callbacks(ij):
-            ij.ui().showUI()
-            run_callbacks(ij)
+        def show_gui_and_run_callbacks():
+            global gateway
+            gateway = _create_gateway()
+            gateway.ui().showUI()
+            run_callbacks(gateway)
+            return gateway
 
         if macos:
             # NB: This will block the calling (main) thread forever!
             try:
-                gateway = _create_gateway()
-                setupGuiEnvironment(lambda: show_gui_and_run_callbacks(gateway))
+                setupGuiEnvironment(show_gui_and_run_callbacks)
             except ModuleNotFoundError as e:
                 if e.msg == "No module named 'PyObjCTools'":
                     advice = (
@@ -1251,15 +1253,13 @@ def init(
                     raise
         else:
             # Create and show the application.
-            gateway = _create_gateway()
-            show_gui_and_run_callbacks(gateway)
+            gateway = show_gui_and_run_callbacks()
             # We are responsible for our own blocking.
             # TODO: Poll using something better than ui().isVisible().
             while gateway.ui().isVisible():
                 time.sleep(1)
 
-        del gateway
-        return None
+        return gateway
 
     # HEADLESS or INTERACTIVE mode: create the gateway and return it.
     return run_callbacks(_create_gateway())

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,7 @@
+def test_when_imagej_starts(ij):
+    """
+    The ImageJ2 gateway test fixture registers a callback function via
+    when_imagej_starts, which injects a small piece of data into the gateway
+    object. We check for that data here to make sure the callback happened.
+    """
+    assert "success" == getattr(ij, "_when_imagej_starts_result", None)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -4,4 +4,4 @@ def test_when_imagej_starts(ij):
     when_imagej_starts, which injects a small piece of data into the gateway
     object. We check for that data here to make sure the callback happened.
     """
-    assert "success" == getattr(ij, "_when_imagej_starts_result", None)
+    assert True is getattr(ij, "_testing", True)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -4,4 +4,4 @@ def test_when_imagej_starts(ij):
     when_imagej_starts, which injects a small piece of data into the gateway
     object. We check for that data here to make sure the callback happened.
     """
-    assert True is getattr(ij, "_testing", True)
+    assert True is getattr(ij, "_testing", None)

--- a/tests/test_ctypes.py
+++ b/tests/test_ctypes.py
@@ -29,14 +29,14 @@ parameters = [
 
 
 @pytest.mark.parametrize(argnames="ctype,jtype_str,value", argvalues=parameters)
-def test_ctype_to_realtype(ij_fixture, ctype, jtype_str, value):
+def test_ctype_to_realtype(ij, ctype, jtype_str, value):
     py_type = ctype(value)
     # Convert the ctype into a RealType
-    converted = ij_fixture.py.to_java(py_type)
+    converted = ij.py.to_java(py_type)
     jtype = sj.jimport(jtype_str)
     assert isinstance(converted, jtype)
     assert converted.get() == value
     # Convert the RealType back into a ctype
-    converted_back = ij_fixture.py.from_java(converted)
+    converted_back = ij.py.from_java(converted)
     assert isinstance(converted_back, ctype)
     assert converted_back.value == value

--- a/tests/test_fiji.py
+++ b/tests/test_fiji.py
@@ -4,23 +4,23 @@ import scyjava as sj
 # -- Tests --
 
 
-def test_plugins_load_using_pairwise_stitching(ij_fixture):
+def test_plugins_load_using_pairwise_stitching(ij):
     try:
         sj.jimport("plugin.Stitching_Pairwise")
     except TypeError:
         pytest.skip("No Pairwise Stitching plugin available. Skipping test.")
 
-    if not ij_fixture.legacy:
+    if not ij.legacy:
         pytest.skip("No original ImageJ. Skipping test.")
-    if ij_fixture.ui().isHeadless():
+    if ij.ui().isHeadless():
         pytest.skip("No GUI. Skipping test.")
 
-    tile1 = ij_fixture.IJ.createImage("Tile1", "8-bit random", 512, 512, 1)
-    tile2 = ij_fixture.IJ.createImage("Tile2", "8-bit random", 512, 512, 1)
+    tile1 = ij.IJ.createImage("Tile1", "8-bit random", 512, 512, 1)
+    tile2 = ij.IJ.createImage("Tile2", "8-bit random", 512, 512, 1)
     args = {"first_image": tile1.getTitle(), "second_image": tile2.getTitle()}
-    ij_fixture.py.run_plugin("Pairwise stitching", args)
-    result_name = ij_fixture.WindowManager.getCurrentImage().getTitle()
+    ij.py.run_plugin("Pairwise stitching", args)
+    result_name = ij.WindowManager.getCurrentImage().getTitle()
 
-    ij_fixture.IJ.run("Close All", "")
+    ij.IJ.run("Close All", "")
 
     assert result_name == "Tile1<->Tile2"

--- a/tests/test_image_conversion.py
+++ b/tests/test_image_conversion.py
@@ -14,12 +14,12 @@ from imagej._java import jc
 # -- Image helpers --
 
 
-def get_img(ij_fixture):
+def get_img(ij):
     # Create img
     dims = sj.jarray("j", [5])
     for i in range(len(dims)):
         dims[i] = i + 1
-    img = ij_fixture.op().run("create.img", dims)
+    img = ij.op().run("create.img", dims)
 
     # Populate img with random data
     cursor = img.cursor()
@@ -30,13 +30,13 @@ def get_img(ij_fixture):
     return img
 
 
-def get_imgplus(ij_fixture):
+def get_imgplus(ij):
     """Get a 7D ImgPlus."""
     # get java resources
     Random = sj.jimport("java.util.Random")
     Axes = sj.jimport("net.imagej.axis.Axes")
     UnsignedByteType = sj.jimport("net.imglib2.type.numeric.integer.UnsignedByteType")
-    DatasetService = ij_fixture.get("net.imagej.DatasetService")
+    DatasetService = ij.get("net.imagej.DatasetService")
 
     # test image parameters
     foo = Axes.get("foo")
@@ -194,9 +194,9 @@ def assert_xarray_coords_equal_to_rai_coords(xarr, rai):
             assert xarr_dim_coords[i] == rai_dim_coords[i]
 
 
-def assert_inverted_xarr_equal_to_xarr(dataset, ij_fixture, xarr):
+def assert_inverted_xarr_equal_to_xarr(dataset, ij, xarr):
     # Reversing back to xarray yields original results
-    invert_xarr = ij_fixture.py.from_java(dataset)
+    invert_xarr = ij.py.from_java(dataset)
     assert (xarr.values == invert_xarr.values).all()
     assert list(xarr.dims) == list(invert_xarr.dims)
     for key in xarr.coords:
@@ -313,8 +313,8 @@ def assert_permuted_rai_equal_to_source_rai(imgplus):
                                 ), sample_name
 
 
-def assert_xarray_equal_to_dataset(ij_fixture, xarr, dataset):
-    dataset = ij_fixture.py.to_java(xarr)
+def assert_xarray_equal_to_dataset(ij, xarr, dataset):
+    dataset = ij.py.to_java(xarr)
     axes = [dataset.axis(axnum) for axnum in range(5)]
     labels = [axis.type().getLabel() for axis in axes]
 
@@ -331,52 +331,52 @@ def assert_xarray_equal_to_dataset(ij_fixture, xarr, dataset):
         expected_labels = ["X", "Y", "Z", "Time", "Channel"]
 
     assert expected_labels == labels
-    assert xarr.attrs == ij_fixture.py.from_java(dataset.getProperties())
-    assert xarr.name == ij_fixture.py.from_java(dataset.getName())
+    assert xarr.attrs == ij.py.from_java(dataset.getProperties())
+    assert xarr.name == ij.py.from_java(dataset.getName())
 
 
-def convert_img_and_assert_equality(ij_fixture, img):
-    nparr = ij_fixture.py.from_java(img)
+def convert_img_and_assert_equality(ij, img):
+    nparr = ij.py.from_java(img)
     assert_ndarray_equal_to_img(img, nparr)
 
 
-def convert_ndarray_and_assert_equality(ij_fixture, nparr):
-    img = ij_fixture.py.to_java(nparr)
+def convert_ndarray_and_assert_equality(ij, nparr):
+    img = ij.py.to_java(nparr)
     assert_ndarray_equal_to_img(img, nparr)
 
 
 # -- Tests --
 
 
-def test_ndarray_converts_to_img(ij_fixture):
-    convert_ndarray_and_assert_equality(ij_fixture, get_nparr())
+def test_ndarray_converts_to_img(ij):
+    convert_ndarray_and_assert_equality(ij, get_nparr())
 
 
-def test_img_converts_to_ndarray(ij_fixture):
-    convert_img_and_assert_equality(ij_fixture, get_img(ij_fixture))
+def test_img_converts_to_ndarray(ij):
+    convert_img_and_assert_equality(ij, get_img(ij))
 
 
-def test_cstyle_array_with_labeled_dims_converts(ij_fixture):
+def test_cstyle_array_with_labeled_dims_converts(ij):
     xarr = get_xarr()
-    assert_xarray_equal_to_dataset(ij_fixture, xarr, ij_fixture.py.to_java(xarr))
+    assert_xarray_equal_to_dataset(ij, xarr, ij.py.to_java(xarr))
 
 
-def test_fstyle_array_with_labeled_dims_converts(ij_fixture):
+def test_fstyle_array_with_labeled_dims_converts(ij):
     xarr = get_xarr("F")
-    assert_xarray_equal_to_dataset(ij_fixture, xarr, ij_fixture.py.to_java(xarr))
+    assert_xarray_equal_to_dataset(ij, xarr, ij.py.to_java(xarr))
 
 
-def test_7d_rai_to_python_permute(ij_fixture):
-    assert_permuted_rai_equal_to_source_rai(get_imgplus(ij_fixture))
+def test_7d_rai_to_python_permute(ij):
+    assert_permuted_rai_equal_to_source_rai(get_imgplus(ij))
 
 
-def test_dataset_converts_to_xarray(ij_fixture):
+def test_dataset_converts_to_xarray(ij):
     xarr = get_xarr()
-    dataset = ij_fixture.py.to_java(xarr)
-    assert_inverted_xarr_equal_to_xarr(dataset, ij_fixture, xarr)
+    dataset = ij.py.to_java(xarr)
+    assert_inverted_xarr_equal_to_xarr(dataset, ij, xarr)
 
 
-def test_image_metadata_conversion(ij_fixture):
+def test_image_metadata_conversion(ij):
     # Create a ImageMetadata
     DefaultImageMetadata = sj.jimport("io.scif.DefaultImageMetadata")
     IdentityAxis = sj.jimport("net.imagej.axis.IdentityAxis")
@@ -386,7 +386,7 @@ def test_image_metadata_conversion(ij_fixture):
     lengths[1] = 2
     metadata.populate(
         "test",  # name
-        ij_fixture.py.to_java([IdentityAxis(), IdentityAxis()]),  # axes
+        ij.py.to_java([IdentityAxis(), IdentityAxis()]),  # axes
         lengths,
         4,  # pixelType
         8,  # bitsPerPixel
@@ -402,7 +402,7 @@ def test_image_metadata_conversion(ij_fixture):
     metadata.setThumbSizeY(metadata.getThumbSizeY())
     metadata.setInterleavedAxisCount(metadata.getInterleavedAxisCount())
     # Convert to python
-    py_data = ij_fixture.py.from_java(metadata)
+    py_data = ij.py.from_java(metadata)
     # Assert equality
     assert py_data["thumbSizeX"] == metadata.getThumbSizeX()
     assert py_data["thumbSizeY"] == metadata.getThumbSizeY()
@@ -423,40 +423,40 @@ def test_image_metadata_conversion(ij_fixture):
     assert py_data["tables"] == metadata.getTables()
 
 
-def test_rgb_image_maintains_correct_dim_order_on_conversion(ij_fixture):
+def test_rgb_image_maintains_correct_dim_order_on_conversion(ij):
     xarr = get_xarr()
-    dataset = ij_fixture.py.to_java(xarr)
+    dataset = ij.py.to_java(xarr)
 
     axes = [dataset.axis(axnum) for axnum in range(5)]
     labels = [axis.type().getLabel() for axis in axes]
     assert ["X", "Y", "Z", "Time", "Channel"] == labels
 
     # Test that automatic axis swapping works correctly
-    numpy_image = ij_fixture.py.initialize_numpy_image(dataset)
-    raw_values = ij_fixture.py.rai_to_numpy(dataset, numpy_image)
+    numpy_image = ij.py.initialize_numpy_image(dataset)
+    raw_values = ij.py.rai_to_numpy(dataset, numpy_image)
     assert (xarr.values == np.moveaxis(raw_values, 0, -1)).all()
 
-    assert_inverted_xarr_equal_to_xarr(dataset, ij_fixture, xarr)
+    assert_inverted_xarr_equal_to_xarr(dataset, ij, xarr)
 
 
-def test_no_coords_or_dims_in_xarr(ij_fixture):
+def test_no_coords_or_dims_in_xarr(ij):
     xarr = get_xarr("NoDims")
-    dataset = ij_fixture.py.from_java(xarr)
-    assert_inverted_xarr_equal_to_xarr(dataset, ij_fixture, xarr)
+    dataset = ij.py.from_java(xarr)
+    assert_inverted_xarr_equal_to_xarr(dataset, ij, xarr)
 
 
-def test_linear_coord_on_xarr_conversion(ij_fixture):
+def test_linear_coord_on_xarr_conversion(ij):
     xarr = get_xarr()
-    dataset = ij_fixture.py.to_java(xarr)
+    dataset = ij.py.to_java(xarr)
     axes = dataset.dim_axes
     # all axes should be DefaultLinearAxis
     for ax in axes:
         assert isinstance(ax, jc.DefaultLinearAxis)
 
 
-def test_non_linear_coord_on_xarr_conversion(ij_fixture):
+def test_non_linear_coord_on_xarr_conversion(ij):
     xarr = get_non_linear_coord_xarr()
-    dataset = ij_fixture.py.to_java(xarr)
+    dataset = ij.py.to_java(xarr)
     axes = dataset.dim_axes
     # axes [0, 1] should be EnumeratedAxis with axis 2 as DefaultLinearAxis
     for i in range(2):
@@ -464,18 +464,18 @@ def test_non_linear_coord_on_xarr_conversion(ij_fixture):
     assert isinstance(axes[-1], jc.DefaultLinearAxis)
 
 
-def test_non_numeric_coord_on_xarr_conversion(ij_fixture):
+def test_non_numeric_coord_on_xarr_conversion(ij):
     xarr = get_non_numeric_coord_xarr()
-    dataset = ij_fixture.py.to_java(xarr)
+    dataset = ij.py.to_java(xarr)
     axes = dataset.dim_axes
     # all axes should be DefaultLinearAxis
     for ax in axes:
         assert isinstance(ax, jc.DefaultLinearAxis)
 
 
-def test_index_image_converts_to_imglib_roi(ij_fixture):
+def test_index_image_converts_to_imglib_roi(ij):
     index_narr = get_index_narr()
-    roi_tree = convert.index_img_to_roi_tree(ij_fixture, index_narr)
+    roi_tree = convert.index_img_to_roi_tree(ij, index_narr)
     # ROI dimensions (max_a, max_b, min_a, min_b)
     ref_roi_dims = (
         (150.0, 150.0, 50.0, 50.0),
@@ -488,8 +488,8 @@ def test_index_image_converts_to_imglib_roi(ij_fixture):
         rois.append(roi_tree.children().get(i).data())
     # contour/ROI dimensions should match roi_dims
     for i in range(3):
-        max_dims = ij_fixture.py.from_java(rois[i].maxAsDoubleArray())
-        min_dims = ij_fixture.py.from_java(rois[i].minAsDoubleArray())
+        max_dims = ij.py.from_java(rois[i].maxAsDoubleArray())
+        min_dims = ij.py.from_java(rois[i].minAsDoubleArray())
         roi_dims = np.concatenate((max_dims, min_dims))
         for j in range(4):
             assert ref_roi_dims[i][j] == roi_dims[j]
@@ -568,21 +568,21 @@ xarr_conversion_parameters = [
     argvalues=dataset_conversion_parameters,
 )
 def test_direct_to_dataset_conversions(
-    ij_fixture, im_req, obj_type, new_dims, exp_dims, exp_shape
+    ij, im_req, obj_type, new_dims, exp_dims, exp_shape
 ):
     # get image data
     if obj_type == "java":
-        im_data = im_req(ij_fixture)
+        im_data = im_req(ij)
     else:
         im_data = im_req()
     # convert the image data to net.image.Dataset
-    ds_out = ij_fixture.py.to_dataset(im_data, dim_order=new_dims)
+    ds_out = ij.py.to_dataset(im_data, dim_order=new_dims)
     assert ds_out.dims == exp_dims
     assert ds_out.shape == exp_shape
     if hasattr(im_data, "coords") and obj_type == "python":
         assert_xarray_coords_equal_to_rai_coords(im_data, ds_out)
     if images.is_xarraylike(im_data):
-        assert_xarray_equal_to_dataset(ij_fixture, im_data, ds_out)
+        assert_xarray_equal_to_dataset(ij, im_data, ds_out)
     if (images.is_arraylike is True) and (images.is_xarraylike is False):
         assert_ndarray_equal_to_img(ds_out, im_data)
 
@@ -590,14 +590,14 @@ def test_direct_to_dataset_conversions(
 @pytest.mark.parametrize(
     argnames="im_req,obj_type,new_dims,exp_shape", argvalues=img_conversion_parameters
 )
-def test_direct_to_img_conversions(ij_fixture, im_req, obj_type, new_dims, exp_shape):
+def test_direct_to_img_conversions(ij, im_req, obj_type, new_dims, exp_shape):
     # get image data
     if obj_type == "java":
-        im_data = im_req(ij_fixture)
+        im_data = im_req(ij)
     else:
         im_data = im_req()
     # convert the image data to Img
-    img_out = ij_fixture.py.to_img(im_data, dim_order=new_dims)
+    img_out = ij.py.to_img(im_data, dim_order=new_dims)
     assert img_out.shape == exp_shape
     if images.is_xarraylike(im_data):
         assert_ndarray_equal_to_img(
@@ -612,15 +612,15 @@ def test_direct_to_img_conversions(ij_fixture, im_req, obj_type, new_dims, exp_s
     argvalues=xarr_conversion_parameters,
 )
 def test_direct_to_xarray_conversion(
-    ij_fixture, im_req, obj_type, new_dims, exp_dims, exp_shape
+    ij, im_req, obj_type, new_dims, exp_dims, exp_shape
 ):
     # get image data
     if obj_type == "java":
-        im_data = im_req(ij_fixture)
+        im_data = im_req(ij)
     else:
         im_data = im_req()
     # convert the image data to xarray
-    xarr_out = ij_fixture.py.to_xarray(im_data, dim_order=new_dims)
+    xarr_out = ij.py.to_xarray(im_data, dim_order=new_dims)
     assert xarr_out.dims == exp_dims
     assert xarr_out.shape == exp_shape
     if hasattr(im_data, "dim_axes") and obj_type == "java":

--- a/tests/test_labeling.py
+++ b/tests/test_labeling.py
@@ -31,16 +31,16 @@ def py_labeling():
 
 
 @pytest.fixture(scope="module")
-def java_labeling(ij_fixture):
+def java_labeling(ij):
     img = np.zeros((4, 4), dtype=np.int32)
     img[:2, :2] = 6
     img[:2, 2:] = 3
     img[2:, :2] = 7
     img[2:, 2:] = 4
-    img_java = ij_fixture.py.to_java(img)
+    img_java = ij.py.to_java(img)
     example_lists = [[], [1], [2], [1, 2], [2, 3], [3], [1, 4], [3, 4]]
     sets = [set(example) for example in example_lists]
-    sets_java = ij_fixture.py.to_java(sets)
+    sets_java = ij.py.to_java(sets)
 
     ImgLabeling = sj.jimport("net.imglib2.roi.labeling.ImgLabeling")
     return ImgLabeling.fromImageAndLabelSets(img_java, sets_java)
@@ -61,21 +61,21 @@ def assert_labels_equality(
 # -- Tests --
 
 
-def test_py_to_java(ij_fixture, py_labeling, java_labeling):
-    j_convert = ij_fixture.py.to_java(py_labeling)
+def test_py_to_java(ij, py_labeling, java_labeling):
+    j_convert = ij.py.to_java(py_labeling)
     # Assert indexImg equality
-    expected_img = ij_fixture.py.from_java(java_labeling.getIndexImg())
-    actual_img = ij_fixture.py.from_java(j_convert.getIndexImg())
+    expected_img = ij.py.from_java(java_labeling.getIndexImg())
+    actual_img = ij.py.from_java(j_convert.getIndexImg())
     assert np.array_equal(expected_img, actual_img)
     # Assert label sets equality
-    expected_labels = ij_fixture.py.from_java(java_labeling.getMapping().getLabelSets())
-    actual_labels = ij_fixture.py.from_java(j_convert.getMapping().getLabelSets())
+    expected_labels = ij.py.from_java(java_labeling.getMapping().getLabelSets())
+    actual_labels = ij.py.from_java(j_convert.getMapping().getLabelSets())
     assert expected_labels == actual_labels
 
 
-def test_java_to_py(ij_fixture, py_labeling, java_labeling):
+def test_java_to_py(ij, py_labeling, java_labeling):
     # Convert
-    p_convert = ij_fixture.py.from_java(java_labeling)
+    p_convert = ij.py.from_java(java_labeling)
     # Assert indexImg equality
     exp_img, exp_labels = py_labeling.get_result()
     act_img, act_labels = p_convert.get_result()
@@ -88,10 +88,10 @@ def test_java_to_py(ij_fixture, py_labeling, java_labeling):
     )
 
 
-def test_py_java_py(ij_fixture, py_labeling):
+def test_py_java_py(ij, py_labeling):
     # Convert
-    to_java = ij_fixture.py.to_java(py_labeling)
-    back_to_py = ij_fixture.py.from_java(to_java)
+    to_java = ij.py.to_java(py_labeling)
+    back_to_py = ij.py.from_java(to_java)
     print(py_labeling.label_sets)
     print(back_to_py.label_sets)
     # Assert indexImg equality

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -14,8 +14,8 @@ def arr():
 
 
 @pytest.fixture(scope="module")
-def results_table(ij_fixture):
-    if ij_fixture.legacy and ij_fixture.legacy.isActive():
+def results_table(ij):
+    if ij.legacy and ij.legacy.isActive():
         ResultsTable = sj.jimport("ij.measure.ResultsTable")
         rt = ResultsTable.getResultsTable()
 
@@ -55,13 +55,13 @@ def ensure_legacy_enabled(ij):
 # -- Tests --
 
 
-def test_convert_imageplus_to_python(ij_fixture):
-    ensure_legacy_enabled(ij_fixture)
+def test_convert_imageplus_to_python(ij):
+    ensure_legacy_enabled(ij)
 
     w = 30
     h = 20
-    imp = ij_fixture.IJ.createImage("Ramp", "16-bit ramp", w, h, 2, 3, 5)
-    xarr = ij_fixture.py.from_java(imp)
+    imp = ij.IJ.createImage("Ramp", "16-bit ramp", w, h, 2, 3, 5)
+    xarr = ij.py.from_java(imp)
     assert xarr.dims == ("t", "pln", "row", "col", "ch")
     assert xarr.shape == (5, 3, h, w, 2)
 
@@ -82,11 +82,11 @@ def test_convert_imageplus_to_python(ij_fixture):
                 assert all((plane == xarr[t, z, :, :, c]).data.flatten())
 
 
-def test_run_plugin(ij_fixture):
-    ensure_legacy_enabled(ij_fixture)
+def test_run_plugin(ij):
+    ensure_legacy_enabled(ij)
 
-    ramp = ij_fixture.IJ.createImage("Tile1", "8-bit ramp", 10, 10, 1)
-    ij_fixture.py.run_plugin("Gaussian Blur...", args={"sigma": 3}, imp=ramp)
+    ramp = ij.IJ.createImage("Tile1", "8-bit ramp", 10, 10, 1)
+    ij.py.run_plugin("Gaussian Blur...", args={"sigma": 3}, imp=ramp)
     values = [ramp.getPixel(x, y)[0] for x in range(10) for y in range(10)]
     # fmt: off
     assert values == [
@@ -104,54 +104,54 @@ def test_run_plugin(ij_fixture):
     # fmt: on
 
 
-def test_get_imageplus_synchronizes_from_imagej_to_imagej2(ij_fixture, arr):
-    ensure_legacy_enabled(ij_fixture)
-    ensure_gui_available(ij_fixture)
+def test_get_imageplus_synchronizes_from_imagej_to_imagej2(ij, arr):
+    ensure_legacy_enabled(ij)
+    ensure_gui_available(ij)
 
     original = arr[0, 0]
-    ds = ij_fixture.py.to_java(arr)
-    ij_fixture.ui().show(ds)
+    ds = ij.py.to_java(arr)
+    ij.ui().show(ds)
     macro = """run("Add...", "value=5");"""
-    ij_fixture.py.run_macro(macro)
+    ij.py.run_macro(macro)
 
     assert arr[0, 0] == original + 5
 
 
-def test_synchronize_from_imagej_to_numpy(ij_fixture, arr):
-    ensure_legacy_enabled(ij_fixture)
-    ensure_gui_available(ij_fixture)
+def test_synchronize_from_imagej_to_numpy(ij, arr):
+    ensure_legacy_enabled(ij)
+    ensure_gui_available(ij)
 
     original = arr[0, 0]
-    ds = ij_fixture.py.to_dataset(arr)
-    ij_fixture.ui().show(ds)
-    imp = ij_fixture.py.active_imageplus()
+    ds = ij.py.to_dataset(arr)
+    ij.ui().show(ds)
+    imp = ij.py.active_imageplus()
     imp.getProcessor().add(5)
-    ij_fixture.py.sync_image(imp)
+    ij.py.sync_image(imp)
 
     assert arr[0, 0] == original + 5
 
 
-def test_window_to_numpy_converts_active_image_to_xarray(ij_fixture, arr):
-    ensure_legacy_enabled(ij_fixture)
-    ensure_gui_available(ij_fixture)
+def test_window_to_numpy_converts_active_image_to_xarray(ij, arr):
+    ensure_legacy_enabled(ij)
+    ensure_gui_available(ij)
 
-    ds = ij_fixture.py.to_dataset(arr)
-    ij_fixture.ui().show(ds)
-    new_arr = ij_fixture.py.active_xarray()
+    ds = ij.py.to_dataset(arr)
+    ij.ui().show(ds)
+    new_arr = ij.py.active_xarray()
     assert (arr == new_arr.values).all
 
 
-def test_functions_throw_warning_if_legacy_not_enabled(ij_fixture):
-    ensure_legacy_disabled(ij_fixture)
+def test_functions_throw_warning_if_legacy_not_enabled(ij):
+    ensure_legacy_disabled(ij)
 
     with pytest.raises(ImportError):
-        ij_fixture.py.active_imageplus()
+        ij.py.active_imageplus()
 
 
-def test_results_table_to_pandas_dataframe(ij_fixture, results_table):
-    ensure_legacy_enabled(ij_fixture)
+def test_results_table_to_pandas_dataframe(ij, results_table):
+    ensure_legacy_enabled(ij)
 
-    df = ij_fixture.py.from_java(results_table)
+    df = ij.py.from_java(results_table)
     for col in range(5):
         rt_col = list(results_table.getColumn(col))
         df_col = df[f"Column {col}"].tolist()

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -4,13 +4,13 @@ import scyjava as sj
 # -- Tests --
 
 
-def test_frangi(ij_fixture):
+def test_frangi(ij):
     input_array = np.array(
         [[1000, 1000, 1000, 2000, 3000], [5000, 8000, 13000, 21000, 34000]]
     )
     result = np.zeros(input_array.shape)
-    ij_fixture.op().filter().frangiVesselness(
-        ij_fixture.py.to_java(result), ij_fixture.py.to_java(input_array), [1, 1], 4
+    ij.op().filter().frangiVesselness(
+        ij.py.to_java(result), ij.py.to_java(input_array), [1, 1], 4
     )
     correct_result = np.array(
         [[0, 0, 0, 0.94282, 0.94283], [0, 0, 0, 0.94283, 0.94283]]
@@ -19,14 +19,12 @@ def test_frangi(ij_fixture):
     assert (result == correct_result).all()
 
 
-def test_gaussian(ij_fixture):
+def test_gaussian(ij):
     input_array = np.array(
         [[1000, 1000, 1000, 2000, 3000], [5000, 8000, 13000, 21000, 34000]]
     )
     sigmas = [10.0] * 2
-    output_array = (
-        ij_fixture.op().filter().gauss(ij_fixture.py.to_java(input_array), sigmas)
-    )
+    output_array = ij.op().filter().gauss(ij.py.to_java(input_array), sigmas)
     result = []
     correct_result = [8435, 8435, 8435, 8435]
     ra = output_array.randomAccess()
@@ -37,7 +35,7 @@ def test_gaussian(ij_fixture):
     assert result == correct_result
 
 
-def test_top_hat(ij_fixture):
+def test_top_hat(ij):
     ArrayList = sj.jimport("java.util.ArrayList")
     HyperSphereShape = sj.jimport("net.imglib2.algorithm.neighborhood.HyperSphereShape")
     Views = sj.jimport("net.imglib2.view.Views")
@@ -49,12 +47,12 @@ def test_top_hat(ij_fixture):
         [[1000, 1000, 1000, 2000, 3000], [5000, 8000, 13000, 21000, 34000]]
     )
     output_array = np.zeros(input_array.shape)
-    java_out = Views.iterable(ij_fixture.py.to_java(output_array))
-    java_in = ij_fixture.py.to_java(input_array)
+    java_out = Views.iterable(ij.py.to_java(output_array))
+    java_in = ij.py.to_java(input_array)
     shapes = ArrayList()
     shapes.add(HyperSphereShape(5))
 
-    ij_fixture.op().morphology().topHat(java_out, java_in, shapes)
+    ij.op().morphology().topHat(java_out, java_in, shapes)
     itr = java_out.iterator()
     while itr.hasNext():
         result.append(itr.next().get())
@@ -62,15 +60,15 @@ def test_top_hat(ij_fixture):
     assert result == correct_result
 
 
-def test_image_math(ij_fixture):
+def test_image_math(ij):
     Views = sj.jimport("net.imglib2.view.Views")
 
     input_array = np.array([[1, 1, 2], [3, 5, 8]])
     result = []
     correct_result = [192, 198, 205, 192, 198, 204]
-    java_in = Views.iterable(ij_fixture.py.to_java(input_array))
+    java_in = Views.iterable(ij.py.to_java(input_array))
     java_out = (
-        ij_fixture.op()
+        ij.op()
         .image()
         .equation(java_in, "64 * (Math.sin(0.1 * p[0]) + Math.cos(0.1 * p[1])) + 128")
     )


### PR DESCRIPTION
# Update
Update I wanted to preserve the original text (below) for this PR as its relevant to the goals (_i.e._ create a better experience for macOS users). With the awesome work that @ctrueden has done with `jaunch` we now have a way to actually support `interactive` mode on macOS. This PR introduces the following new elements and also paves the way for interactive mode on macOS via `jaunch`.

This PR adds:

- A "global gateway" which enables other projects to hook into a already running instance of imagej (e.g. napari-imagej).
- A callback mechanism which enables users to register functions with `when_imagej_starts()`. This can enable some GUI related workflows on macOS (a kind of limited psuedo-interactive mode). See notebook 5 section `5.2` for the relevant documentation. This callback mechanism is **not compatible with napari**.
- An `override` flag to the main `init` method. This flag will enable users/developers to bypass initialization checks/blocks we've put in place to stop unsupported/application breaking behavior -- mainly `interactive` mode on macOS. To test interactive mode on macOS:
    - Install/setup [jaunch](https://forum.image.sc/t/jaunch-a-new-java-launcher-test-fiji-with-java-21/92058).
    - Modify `jaunch`'s `fiji.py` file. Add the `override=True` flag to `ij = imagej.init(app_dir, mode="interactive")` on line 72.
    - Jaunch Fiji with `./fiji-macos-universal -i --python`.

Some other relevant information: Based on what I now understand about Python's threading system and some experimentation on macOS/Linux with `jaunch`, Python will always think its in a main thread. There is no way (from what I gather) to know if a particular Python instance was started with/in a `pthread`. Instead, threads that are spawned from an already running instance, say in a function that creates threads, are identified as "non-main" thread. This is obvious, but it would have been cool if there was a way to know about how the current instance was started.

# Original text

Until we can find a true interactive mode for macOS (see https://github.com/imagej/pyimagej/issues/298) this callback mechanism gives macOS users the ability to run their desired Python functions before the REPL is locked by the `AppHelper.runConsoleEventLoop()`.

Here's how you register a callback with PyImageJ:

```python
import imagej

# register a function that takes no params
imagej.when_imagej_starts(lambda: func())

# register an ImageJ function (if a parameter is present, assume its ij)
imagej.when_imagej_starts(lambda ij: ij.RoiManager.getRoiManager())

# initialize ImageJ in GUI mode
ij = imagej.init(mode='gui')
```

Unfortunately this callback strategy doesn't work with `napari`. Registering the callback `lambda: napari.Viewer()` results in this segfault:

```java
(pyimagej) loci@dyn-144-92-48-223 Documents % python test.py
WARNING: package sun.awt.X11 not in java.desktop
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by net.imagej.legacy.IJ1Helper (file:/Users/loci/.jgo/net.imagej/imagej/RELEASE/28b74e6959b0634f2a8e10c27afe06e7039fb4a0dc582d9746d028ba40e5bd04/imagej-legacy-1.2.1.jar) to method com.apple.eawt.Application.getApplication()
WARNING: Please consider reporting this to the maintainers of net.imagej.legacy.IJ1Helper
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGILL (0x4) at pc=0x00007ff8116c90c2, pid=2487, tid=42247
#
# JRE version: OpenJDK Runtime Environment Zulu11.70+15-CA (11.0.22+7) (build 11.0.22+7-LTS)
# Java VM: OpenJDK 64-Bit Server VM Zulu11.70+15-CA (11.0.22+7-LTS, mixed mode, tiered, compressed oops, g1 gc, bsd-amd64)
# Problematic frame:
# C  [libdispatch.dylib+0x50c2]  _dispatch_assert_queue_fail+0x66
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# An error report file with more information is saved as:
# /Users/loci/Documents/hs_err_pid2487.log
#
# If you would like to submit a bug report, please visit:
#   http://www.azul.com/support/
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#
zsh: abort      python test.py
(pyimagej) loci@dyn-144-92-48-223 Documents % 
```