### PR TITLE
Use the `ruff` linter/formatter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,18 +55,11 @@ jobs:
       - uses: actions/setup-python@v3
 
       - name: Lint code
-        uses: psf/black@stable
-
-      - name: Flake code
         run: |
-          python -m pip install flake8 Flake8-pyproject flake8-typing-imports
-          python -m flake8 src tests
-
-      - name: Check import ordering
-        uses: isort/isort-action@master
-        with:
-          configuration: --check-only
-
+          python -m pip install ruff
+          ruff check
+          ruff format --check
+        
       - name: Validate pyproject.toml
         run: |
           python -m pip install validate-pyproject[all]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,24 +1,12 @@
 repos:
-  - repo: https://github.com/myint/autoflake
-    rev: v1.4
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # ruff version
+    rev: v0.6.2
     hooks:
-      - id: autoflake
-        args: ["--in-place", "--remove-all-unused-imports"]
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - "flake8-typing-imports"
-          - "Flake8-pyproject"
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-  - repo: https://github.com/psf/black
-    rev: 22.3.0
-    hooks:
-      - id: black
+      # run the linter
+      - id: ruff
+      # run the formatter
+      - id: ruff-format
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.10.1
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ check:
 lint: check
 	bin/lint.sh
 
+fmt: check
+	bin/fmt.sh
+
 test: check
 	bin/test.sh
 

--- a/bin/fmt.sh
+++ b/bin/fmt.sh
@@ -4,10 +4,8 @@ dir=$(dirname "$0")
 cd "$dir/.."
 
 exitCode=0
-ruff check
+ruff check --fix
 code=$?; test $code -eq 0 || exitCode=$code
-ruff format --check
-code=$?; test $code -eq 0 || exitCode=$code
-validate-pyproject pyproject.toml
+ruff format
 code=$?; test $code -eq 0 || exitCode=$code
 exit $exitCode

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -39,22 +39,17 @@ dependencies:
   - pooch # for scikit image
   - scikit-image
   # Developer tools
-  - autopep8
-  - black
-  - flake8
-  - flake8-typing-imports
-  - isort
   - myst-nb
   - pre-commit
   - python-build
   - pytest
   - pytest-cov
+  - ruff
   - sphinx
   - sphinx_rtd_theme
   - pip
   - pip:
     - readthedocs-sphinx-search
-    - flake8-pyproject
     - validate-pyproject[all]
     # Project from source
     - -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,17 +49,12 @@ dependencies = [
 # NB: Keep this in sync with dev-environment.yml!
 # Development tools
 dev = [
-    "autopep8",
-    "black",
     "build",
-    "flake8",
-    "flake8-pyproject",
-    "flake8-typing-imports",
-    "isort",
     "myst-nb",
     "pre-commit",
     "pytest",
     "pytest-cov",
+    "ruff",
     "sphinx",
     "sphinx_rtd_theme",
     "validate-pyproject[all]",
@@ -96,20 +91,19 @@ include-package-data = false
 where = ["src"]
 namespaces = false
 
-[tool.black]
-exclude = 'dist|doc'
+# ruff configuration
+[tool.ruff]
+line-length = 88
+src = ["src", "tests"]
+include = ["pyproject.toml", "src/**/*.py", "tests/**/*.py"]
+extend-exclude = ["bin", "build", "dist"]
 
-# Thanks to Flake8-pyproject, we can configure flake8 here!
-[tool.flake8]
-exclude = ["build", "dist", "doc"]
+[tool.ruff.lint]
 extend-ignore = ["E203"]
-# See https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
-max-line-length = 88
-min_python_version = "3.8"
 
-[tool.isort]
-profile = "black"
-skip = ["doc"]
+[tool.ruff.lint.per-file-ignores]
+# Ignore `E402` (import violations) in all `__init__.py` files, and in `path/to/file.py`.
+"__init__.py" = ["E402", "F401"]
 
 [tool.pytest.ini_options]
 addopts = "--ignore=docs"

--- a/src/imagej/doctor.py
+++ b/src/imagej/doctor.py
@@ -14,6 +14,7 @@ To enable debug-level logging:
     import imagej
     ij = imagej.init()
 """
+
 import importlib
 import logging
 import os


### PR DESCRIPTION
Today I ran into a deprecation bug/error with `autoflake` and `distutils` with Python 3.12 which irritated me. This PR implements the `ruff` linter/formater for PyImageJ and replaces `autopep8`, `black`, `flake8`, and `isort`.