### PR TITLE
Improve Jupyter Dynamic Install instructions

### DIFF
--- a/doc/Install.md
+++ b/doc/Install.md
@@ -91,7 +91,12 @@ For your first cell, write:
 import sys, os
 prefix = sys.prefix.replace("\\", "/") # Handle Windows Paths
 %mamba install --yes --prefix {prefix} -c conda-forge pyimagej openjdk=11
-os.environ['JAVA_HOME'] = os.sep.join(sys.executable.split(os.sep)[:-2] + ['jre'])
+jvm_lib_path = [sys.prefix, 'lib', 'jvm']
+
+# platform specific JVM lib path locations
+if sys.platform == "win32":
+    jvm_lib_path.insert(1, 'Library')
+os.environ['JAVA_HOME'] = os.sep.join(jvm_lib_path)
 ```
 
 This approach is useful for [JupyterHub](https://jupyter.org/hub) on the cloud,

--- a/doc/Install.md
+++ b/doc/Install.md
@@ -89,7 +89,8 @@ It is possible to dynamically install PyImageJ from within a Jupyter notebook.
 For your first cell, write:
 ```
 import sys, os
-!mamba install --yes --prefix {sys.prefix} pyimagej openjdk=11
+prefix = sys.prefix.replace("\\", "/") # Handle Windows Paths
+%mamba install --yes --prefix {prefix} -c conda-forge pyimagej openjdk=11
 os.environ['JAVA_HOME'] = os.sep.join(sys.executable.split(os.sep)[:-2] + ['jre'])
 ```
 


### PR DESCRIPTION
This commit makes a few changes:
* Uses "%mamba" over "!mamba" - has support for micromamba
* Adds "-c conda-forge" - I found this necessary, at least for micromamba
* Adds prefix delimiter manipulation to account for Windows paths

@elevans can you test this out on some other platforms and make sure this works?