### PR TITLE
Minor doc changes in 11-Working-with-the-original-ImageJ.ipynb

### DIFF
--- a/doc/11-Working-with-the-original-ImageJ.ipynb
+++ b/doc/11-Working-with-the-original-ImageJ.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook is part of the PyImageJ [Tutorial Series](./notebooks.rst), and assumes familiarity with the ImageJ API. Dedicated tutorials for ImageJ can be found [here](https://imagej.net/tutorials/).S"
+    "This notebook is part of the PyImageJ [Tutorial Series](./notebooks.rst), and assumes familiarity with the ImageJ API. Dedicated tutorials for ImageJ can be found [here](https://imagej.net/tutorials/)."
    ]
   },
   {

--- a/doc/11-Working-with-the-original-ImageJ.ipynb
+++ b/doc/11-Working-with-the-original-ImageJ.ipynb
@@ -507,7 +507,7 @@
     "The `ij.py.run_macro` function lets you run [ImageJ macros](https://imagej.net/scripting/macro) from Python.\n",
     "\n",
     "Before you get too excited, there are some things you should know:\n",
-    "* The macro language does not support the complete ImageJ API, only a set of [built-in functions](https://imagej.nih.gov/ij/developer/macro/functions.html), although there are [ways to work around this](https://imagej.net/scripting/macro#overcoming-limitations).\n",
+    "* The macro language does not support the complete ImageJ API, only a set of [built-in functions](https://imagej.net/ij/developer/macro/functions.html), although there are [ways to work around this](https://imagej.net/scripting/macro#overcoming-limitations).\n",
     "* Macros are executed by a custom interpreter that is buggier and less well tested than other script languages (Groovy, JRuby, Jython, etc.).\n",
     "* Macros are not intended to run concurrently, meaning you should only run one macro at a time.\n",
     "* Macros only support three data types: numbers, strings, and simple arrays. Images are passed via numerical IDs.\n",


### PR DESCRIPTION
1. `https://imagej.nih.gov/ij/developer/macro/functions.html` to `https://imagej.net/ij/developer/macro/functions.html`
2. removed unnecessary comma and a random `S`