### PR TITLE
Simplify Named RAI name conversion

### DIFF
--- a/src/imagej/convert.py
+++ b/src/imagej/convert.py
@@ -237,8 +237,7 @@ def java_to_xarray(ij: "jc.ImageJ", jobj) -> xr.DataArray:
     xr_dims.reverse()
     xr_dims = dims._convert_dims(xr_dims, direction="python")
     xr_coords = dims._get_axes_coords(xr_axes, xr_dims, narr.shape)
-    name = jobj.getName() if isinstance(jobj, jc.Named) else None
-    name = ij.py.from_java(name)
+    name = str(jobj.getName()) if isinstance(jobj, jc.Named) else None
     return xr.DataArray(narr, dims=xr_dims, coords=xr_coords, attrs=xr_attrs, name=name)
 
 

--- a/tests/test_image_conversion.py
+++ b/tests/test_image_conversion.py
@@ -650,6 +650,8 @@ def test_direct_to_xarray_conversion(
         im_data = im_req()
     # convert the image data to xarray
     xarr_out = ij.py.to_xarray(im_data, dim_order=new_dims)
+    name = xarr_out.name
+    assert name is None or isinstance(name, str)
     assert xarr_out.dims == exp_dims
     assert xarr_out.shape == exp_shape
     if hasattr(im_data, "dim_axes") and obj_type == "java":


### PR DESCRIPTION
When you use `ij.py.from_java`, you open the door to unwanted conversion behavior. As an example, if `jobj` is linked to an ImagePlus, the conversion of the name can utilize imagej-legacy's [`StringToImagePlusConverter`](https://github.com/imagej/imagej-legacy/blob/d83148862add04b2f0fa22b9cc61e18f360ee15c/src/main/java/net/imagej/legacy/convert/StringToImagePlusConverter.java#L68), making the resulting `xarray.name` an `ndarray`.

This was the source of https://github.com/imagej/napari-imagej/issues/304

@elevans can you think of any worthwhile tests to add here?