### PR TITLE
Test xarray naming post conversion and enable GUI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,9 +45,10 @@ jobs:
         python -m pip install -e '.[dev]'
 
     - name: Test PyImageJ
-      shell: bash
-      run: |
-        bin/test.sh
+      uses: GabrielBB/xvfb-action@v1
+      with:
+        run:
+          bash bin/test.sh
 
   ensure-clean-code:
     runs-on: ubuntu-latest

--- a/conftest.py
+++ b/conftest.py
@@ -21,7 +21,7 @@ def pytest_addoption(parser):
         "--headless",
         type=str2bool,
         action="store",
-        default=True,
+        default=False,
         help="Start in headless mode",
     )
     parser.addoption(

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,5 @@
 import argparse
-
+import sys
 import pytest
 
 import imagej
@@ -46,6 +46,10 @@ def ij(request):
     imagej.when_imagej_starts(lambda ij: setattr(ij, "_testing", True))
 
     mode = "headless" if headless else "interactive"
+    # set headless mode for macOS only
+    macos = sys.platform == "darwin"
+    if macos:
+        mode = "headless"
     ij = imagej.init(ij_dir, mode=mode, add_legacy=legacy)
 
     yield ij

--- a/tests/test_fiji.py
+++ b/tests/test_fiji.py
@@ -5,22 +5,30 @@ import scyjava as sj
 
 
 def test_plugins_load_using_pairwise_stitching(ij):
+    # get pariwise stiching Fiji plugin, if available
     try:
         sj.jimport("plugin.Stitching_Pairwise")
     except TypeError:
         pytest.skip("No Pairwise Stitching plugin available. Skipping test.")
 
+    # skip if missing legacy or in headless mode
     if not ij.legacy:
         pytest.skip("No original ImageJ. Skipping test.")
     if ij.ui().isHeadless():
         pytest.skip("No GUI. Skipping test.")
 
+    # create random image tiles
     tile1 = ij.IJ.createImage("Tile1", "8-bit random", 512, 512, 1)
     tile2 = ij.IJ.createImage("Tile2", "8-bit random", 512, 512, 1)
+    tile1.show()
+    tile2.show()
+
+    # stich image tiles
     args = {"first_image": tile1.getTitle(), "second_image": tile2.getTitle()}
     ij.py.run_plugin("Pairwise stitching", args)
     result_name = ij.WindowManager.getCurrentImage().getTitle()
 
+    # clean up the windows
     ij.IJ.run("Close All", "")
 
     assert result_name == "Tile1<->Tile2"

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -119,6 +119,8 @@ def test_get_imageplus_synchronizes_from_imagej_to_imagej2(ij, arr):
     ij.ui().show(ds)
     macro = """run("Add...", "value=5");"""
     ij.py.run_macro(macro)
+    imp = ij.WindowManager.getCurrentImage()
+    ij.py.sync_image(imp)
 
     assert arr[0, 0] == original + 5
 

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -154,7 +154,7 @@ def test_linked_dataset_conversion_to_xarray(ij, xarr):
     ensure_gui_available(ij)
 
     # get a dataset, linked to an ImagePlus
-    dataset = ij.py.to_dataset(arr)
+    dataset = ij.py.to_dataset(xarr)
     ij.ui().show(dataset)
 
     # convert the image data to xarray

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -3,6 +3,7 @@ import random
 import numpy as np
 import pytest
 import scyjava as sj
+import xarray
 
 # -- Fixtures --
 
@@ -11,6 +12,11 @@ import scyjava as sj
 def arr():
     empty_array = np.zeros([512, 512])
     return empty_array
+
+
+@pytest.fixture(scope="module")
+def xarr(arr):
+    return xarray.DataArray(arr, name="test_xarray")
 
 
 @pytest.fixture(scope="module")
@@ -139,6 +145,19 @@ def test_window_to_numpy_converts_active_image_to_xarray(ij, arr):
     ij.ui().show(ds)
     new_arr = ij.py.active_xarray()
     assert (arr == new_arr.values).all
+
+
+def test_linked_dataset_convertsion_to_xarray(ij, xarr):
+    ensure_legacy_enabled(ij)
+    ensure_gui_available(ij)
+
+    # get a dataset, linked to an ImagePlus
+    dataset = ij.py.to_dataset(arr)
+    ij.ui().show(dataset)
+
+    # convert the image data to xarray
+    xarr_out = ij.py.to_xarray(dataset)
+    assert xarr_out.name == "test_xarray"
 
 
 def test_functions_throw_warning_if_legacy_not_enabled(ij):

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -147,7 +147,7 @@ def test_window_to_numpy_converts_active_image_to_xarray(ij, arr):
     assert (arr == new_arr.values).all
 
 
-def test_linked_dataset_convertsion_to_xarray(ij, xarr):
+def test_linked_dataset_conversion_to_xarray(ij, xarr):
     ensure_legacy_enabled(ij)
     ensure_gui_available(ij)
 


### PR DESCRIPTION
We merged #323, but we don't have a great test for the fix that reproduced the error, partially because running the test (on CI) would require xvfb. @elevans said he'd look into that - this change should be verified (and merged) after that.