### PR TITLE
Avoid starting up the JVM when logging python errors

### DIFF
--- a/src/imagej/__init__.py
+++ b/src/imagej/__init__.py
@@ -1569,7 +1569,7 @@ def _guess_java_version() -> Optional[int]:
         # This is OK -- it just means no already installed Java is known.
         # But scyjava might download and cache a JDK, so we'll proceed with
         # that understanding.
-        _log_exception(_logger, e)
+        _logger.debug(e)
 
     # In scyjava 1.12.0+, if a JDK fetch is planned, the jvm_version()
     # result will be invalid because that function is reporting on an


### PR DESCRIPTION
There are many locations in `__init__.py` where `_log_exception` is used to log debug messages during ImageJ startup. `log_exception`'s signature suggests that it is only meant to handle Java exceptions, however in many places it is called with Python exceptions. This has the unintended effect of starting up the JVM whenever debug logging is enabled.

We should thus be careful to either (a) use _log_exception everywhere but add case logic to avoid starting up the JVM early, or (b) use _log_exception ONLY when providing a Java exception.