### PR TITLE
Implement ScriptModule functions for Java HashMap

### DIFF
--- a/tests/test_macros_scripts.py
+++ b/tests/test_macros_scripts.py
@@ -46,18 +46,20 @@ def test_imagej_macro(ij):
 
 
 def test_script_output_object(ij):
-    args = {"img": get_img(ij)}
+    input_img = get_img(ij)
+    args = {"img": input_img}
     script = get_script()
     output = ij.py.run_script("Groovy", script, args)
 
-    # check if output is a Java HashMap
-    hm = sj.jimport("java.util.HashMap")
-    assert isinstance(output, hm)
+    # check if output is a ScriptModuleDict adapter object
+    assert str(type(output)).endswith(".ScriptModuleDict'>")
 
-    # check if the HashMap has the ScriptModule patch methods
+    # check returned output value
+    assert output["out"] == 1024
+
+    # check if the returned object has the ScriptModule methods
     assert output.getOutput("out") == 1024
-    assert isinstance(output.getOutputs(), hm)
-    with pytest.raises(NotImplementedError):
-        output.getInput("out")
-    with pytest.raises(NotImplementedError):
-        output.getInputs()
+    assert output.getInput("img") == input_img
+    assert output.getReturnValue() == 1024
+    assert output.context() == ij.context()
+    assert "Groovy" in output.getEngine().getClass().getName()


### PR DESCRIPTION
With commit b1965c6 I fixed the outputs of `run_script` and `run_macro` by returning the promised Java HashMap instead of an instance of a `ScriptModule`. This change however (1) changes the API behavior and (2) breaks any script that depends on the `getOutput()` and `getOutputs()` calls. To alleviate this headache I made, we agreed to implement these methods on the Java HashMap, thereby not breaking scripts calling for outputs. However the `getInput()` and `getInputs()` functions are not implemented as they would exist in a different Hash map. Calling these will raise a `NotImplementedError`.

I also added the appropriate tests for the `JavaHashMapAddons`.

Here is a minimal script to test/play with this behavior:

```python
import imagej
import numpy as np

# initialize imagej2
ij = imagej.init()

# create test data
arr = np.random.randint(0, 65536, size=(512, 512), dtype=np.uint16)

# create script
sc = """
#@ Img img
#@output Integer a
#@output Float b

dims = img.dimensionsAsLongArray()
a = dims[0] + dims[1]
b = dims[0] * dims[1]
"""

# create arg map
args = {"img": arr}
output = ij.py.run_script("Python (Jython)", sc, args)

# this should FAIL on main without this patch
# this should PASS with release because we return a ScriptModule
a = output.getOutput("a")
b = output.getOutput("b")
map = output.getOutputs()
```

One question is if raising a `NotImplementedError` is appropriate here or if we should do something more fancy.